### PR TITLE
598: refresh gives double outline

### DIFF
--- a/org.erlide.core/src/org/erlide/core/internal/model/erlang/ErlModule.java
+++ b/org.erlide.core/src/org/erlide/core/internal/model/erlang/ErlModule.java
@@ -96,9 +96,22 @@ public class ErlModule extends Openable implements IErlModule {
     }
 
     public boolean internalBuildStructure(final IProgressMonitor pm) {
+        final IResource resource = getResource();
+        boolean isInSync = true;
+        if (resource != null) {
+            isInSync = resource.isSynchronized(IResource.DEPTH_ZERO);
+            if (!isInSync) {
+                try {
+                    resource.refreshLocal(IResource.DEPTH_ZERO, null);
+                } catch (final CoreException e) {
+                    ErlLogger.debug(e);
+                }
+            }
+        }
         final IErlParser parser = ErlModelManager.getErlangModel().getParser();
-        parsed = parser.parse(this, scannerName, !parsed, getFilePath(), true);
-        final IResource resource = getCorrespondingResource();
+        parsed = parser.parse(this, scannerName, !parsed, getFilePath(), true)
+                && isInSync;
+
         MarkerUtils.removeTaskMarkersFor(resource);
         // MarkerUtils.createTaskMarkers(resource, scanner.getText());
         return parsed;

--- a/org.erlide.ui/src/org/erlide/ui/editors/erl/ErlangEditor.java
+++ b/org.erlide.ui/src/org/erlide/ui/editors/erl/ErlangEditor.java
@@ -63,10 +63,13 @@ import org.eclipse.jface.viewers.ITreeContentProvider;
 import org.eclipse.jface.viewers.SelectionChangedEvent;
 import org.eclipse.jface.viewers.ViewerComparator;
 import org.eclipse.search.ui.IContextMenuConstants;
+import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.StyledText;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Event;
+import org.eclipse.swt.widgets.Listener;
 import org.eclipse.ui.IEditorInput;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IPartListener2;
@@ -1151,8 +1154,15 @@ public class ErlangEditor extends TextEditor implements IOutlineContentCreator,
                     .prependVerifyKeyListener(getBracketInserter());
         }
 
-        final ProjectionViewer v = (ProjectionViewer) getSourceViewer();
-        v.doOperation(ProjectionViewer.TOGGLE);
+        parent.addListener(SWT.Activate, new Listener() {
+            @Override
+            public void handleEvent(final Event event) {
+                if (event.type == SWT.Activate) {
+                    final ProjectionViewer v = (ProjectionViewer) getSourceViewer();
+                    v.doOperation(ProjectionViewer.TOGGLE);
+                }
+            }
+        });
 
         fEditorSelectionChangedListener = new EditorSelectionChangedListener();
         fEditorSelectionChangedListener.install(getSelectionProvider());

--- a/org.erlide.ui/src/org/erlide/ui/internal/folding/DefaultErlangFoldingStructureProvider.java
+++ b/org.erlide.ui/src/org/erlide/ui/internal/folding/DefaultErlangFoldingStructureProvider.java
@@ -538,19 +538,15 @@ public class DefaultErlangFoldingStructureProvider implements
             boolean structureKnown = false;
             try {
                 structureKnown = fModule.isStructureKnown();
-            } catch (final ErlModelException e1) {
-            }
-            if (structureKnown) {
-                final IErlElementDelta d = new ErlElementDelta(
-                        IErlElementDelta.CHANGED, IErlElementDelta.F_CONTENT,
-                        fModule);
-                processDelta(d);
-            } else {
-                try {
+                if (structureKnown) {
+                    final IErlElementDelta d = new ErlElementDelta(
+                            IErlElementDelta.CHANGED,
+                            IErlElementDelta.F_CONTENT, fModule);
+                    processDelta(d);
+                } else {
                     fModule.open(null);
-                } catch (final ErlModelException e) {
-                    e.printStackTrace();
                 }
+            } catch (final ErlModelException e) {
             }
         }
     }


### PR DESCRIPTION
The model is built independently from the editor (the erlang parser gets the file path and reads the contents from there).

When refresh is pressed for a file that was out of sync, the editor gets the content, but the reconciler doesn't handle it as an initial reconcile, but as a regular one, thus temporarily having the content twice.

Solution: When resource is out of sync, don't build a model!
