### PR TITLE
Fix RuntimeVersion to support OTP R16B03-1

### DIFF
--- a/org.erlide.runtime.tests/src/org/erlide/runtime/RuntimeVersionTest.java
+++ b/org.erlide.runtime.tests/src/org/erlide/runtime/RuntimeVersionTest.java
@@ -32,6 +32,13 @@ public class RuntimeVersionTest {
     }
 
     @Test
+    public void toString_4() {
+        final String expect = "R16B03-1";
+        final RuntimeVersion test = new RuntimeVersion(expect);
+        assertThat(test.toString(), is(expect));
+    }
+
+    @Test
     public void compare_2() {
         final RuntimeVersion test1 = new RuntimeVersion("R12");
         final RuntimeVersion test2 = new RuntimeVersion("R12A");
@@ -91,6 +98,13 @@ public class RuntimeVersionTest {
     public void compare_5a() {
         final RuntimeVersion test1 = new RuntimeVersion("R13A03");
         final RuntimeVersion test2 = new RuntimeVersion("R13B01");
+        assertThat(test1.compareTo(test2), is(lessThan(0)));
+    }
+
+    @Test
+    public void compare_6a() {
+        final RuntimeVersion test1 = new RuntimeVersion("R16B03");
+        final RuntimeVersion test2 = new RuntimeVersion("R16B03-1");
         assertThat(test1.compareTo(test2), is(lessThan(0)));
     }
 

--- a/org.erlide.runtime/src/org/erlide/runtime/runtimeinfo/RuntimeVersion.java
+++ b/org.erlide.runtime/src/org/erlide/runtime/runtimeinfo/RuntimeVersion.java
@@ -26,28 +26,36 @@ public final class RuntimeVersion implements Comparable<RuntimeVersion> {
     private final int major;
     private final int minor;
     private int micro;
+    private int update_level;
 
     public RuntimeVersion(final RuntimeVersion other) {
         major = other.major;
         minor = other.minor;
         micro = other.micro;
+        update_level = other.update_level;
     }
 
-    public RuntimeVersion(final int major, final int minor, final int micro) {
+    public RuntimeVersion(final int major, final int minor, final int micro, final int update_level) {
         // Assert.isTrue(major >= UNUSED);
         // Assert.isTrue(minor >= UNUSED);
         // Assert.isTrue(micro >= UNUSED);
+        // Assert.isTrue(update_level >= UNUSED);
         this.major = major;
         this.minor = minor;
         this.micro = micro;
+        this.update_level = update_level;
+    }
+
+    public RuntimeVersion(final int major, final int minor, final int micro) {
+        this(major, minor, micro, UNUSED);
     }
 
     public RuntimeVersion(final int major, final int minor) {
-        this(major, minor, UNUSED);
+        this(major, minor, UNUSED, UNUSED);
     }
 
     public RuntimeVersion(final int major) {
-        this(major, UNUSED, UNUSED);
+        this(major, UNUSED, UNUSED, UNUSED);
     }
 
     public RuntimeVersion(final String version) {
@@ -59,6 +67,7 @@ public final class RuntimeVersion implements Comparable<RuntimeVersion> {
             major = UNUSED;
             minor = UNUSED;
             micro = UNUSED;
+            update_level = UNUSED;
             return;
         }
         // Assert.isTrue(version.charAt(0) == 'R');
@@ -78,11 +87,20 @@ public final class RuntimeVersion implements Comparable<RuntimeVersion> {
             i++;
             if (major >= 13) {
                 if (i < version.length()) {
-                    micro = Integer.parseInt(version.substring(i));
+                    final int n = version.indexOf('-');
+                    if (n == -1) {
+                        micro = Integer.parseInt(version.substring(i));
+                        update_level = UNUSED;
+                    } else {
+                        micro = Integer.parseInt(version.substring(i, n));
+                        update_level = Integer.parseInt(version.substring(n + 1));
+                    }
                 } else {
                     micro = 0;
+                    update_level = UNUSED;
                 }
             } else {
+                update_level = UNUSED;
                 if (aMicro != null) {
                     micro = Integer.parseInt(aMicro);
                 } else {
@@ -97,10 +115,12 @@ public final class RuntimeVersion implements Comparable<RuntimeVersion> {
         } else {
             minor = UNUSED;
             micro = UNUSED;
+            update_level = UNUSED;
         }
         // Assert.isTrue(major >= UNUSED);
         // Assert.isTrue(minor >= UNUSED);
         // Assert.isTrue(micro >= UNUSED);
+        // Assert.isTrue(update_level >= UNUSED);
     }
 
     @Override
@@ -121,6 +141,10 @@ public final class RuntimeVersion implements Comparable<RuntimeVersion> {
                             m = "0" + m;
                         }
                         result += m;
+                        if (update_level != UNUSED) {
+                            String n = Integer.toString(update_level);
+                            result += "-" + n;
+                        }
                     }
                 }
             }
@@ -142,7 +166,10 @@ public final class RuntimeVersion implements Comparable<RuntimeVersion> {
         if (major == o.major) {
             if (minor == o.minor) {
                 if (micro == o.micro) {
-                    return 0;
+                    if (update_level == o.update_level) {
+                        return 0;
+                    }
+                    return update_level - o.update_level;
                 }
                 return micro - o.micro;
             }


### PR DESCRIPTION
Unlike e.g. R15B03-1, R16B03-1 includes the "-1" suffix in the OTP version.
This crashes Erlide:

```
Caused by: java.lang.NumberFormatException: For input string: "03-1"
    at java.lang.NumberFormatException.forInputString(NumberFormatException.java:65)
    at java.lang.Integer.parseInt(Integer.java:492)
    at java.lang.Integer.parseInt(Integer.java:527)
    at org.erlide.runtime.api.RuntimeVersion.<init>(RuntimeVersion.java:81)
    at org.erlide.runtime.api.RuntimeVersion.getVersion(RuntimeVersion.java:257)
```
