### PR TITLE
Update to OTP23 and debugger support for OTP23/24/25

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v2
@@ -18,14 +18,14 @@ jobs:
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
           ${{ runner.os }}-m2-
-    - uses: gleam-lang/setup-erlang@v1.1.2
+    - uses: erlef/setup-beam@v1
       with:
-        otp-version: 23.2
+        otp-version: '23'
     - name: erl
       run: erl -version
     - uses: actions/setup-ruby@v1
       with:
-        ruby-version: '2.7' 
+        ruby-version: '2.7'
     - name: Build with Maven
       run: PATH=$PATH:/home/runner/.gem/ruby/2.7/bin xvfb-run ./mvnw -B -U clean verify -P help
     - uses: actions/upload-artifact@v2

--- a/extras/org.erlide.licenses/pom.xml
+++ b/extras/org.erlide.licenses/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.erlide</groupId>
 		<artifactId>org.erlide.parent</artifactId>
-        <version>0.60.4-SNAPSHOT</version>
+        <version>0.61.0-SNAPSHOT</version>
 		<relativePath>../..</relativePath>
 	</parent>
 

--- a/extras/wrangler/plugins/org.erlide.wrangler.help/html/general.html
+++ b/extras/wrangler/plugins/org.erlide.wrangler.help/html/general.html
@@ -51,7 +51,7 @@
         <li><a href="http://www.cs.kent.ac.uk/projects/wrangler/">Wrangler home page</a></li>
         <li><a href="https://launchpad.net/~oroszgy/+archive/wrangler">Wrangler installer for Debian Linux</li>
         <li><a href="http://erlide.org">Erlide project site</a></li>
-        <li><a href="https://download.erlide.org/update">Erlide update site</a></li>
+        <li><a href="https://erlide.org/update">Erlide update site</a></li>
         <li><a href="https://github.com/erlang/erlide_eclipse/issues">Erlide bug tracker</a></li>
         <li><a href="http://www.erlang.org">Open source Erlang</a></li>
         <li><a href="http://www.protest-project.eu/">Protest Project</a></li>

--- a/extras/wrangler/plugins/org.erlide.wrangler.refactoring/src/org/erlide/wrangler/refactoring/ui/AboutHandler.java
+++ b/extras/wrangler/plugins/org.erlide.wrangler.refactoring/src/org/erlide/wrangler/refactoring/ui/AboutHandler.java
@@ -66,7 +66,7 @@ public class AboutHandler extends AbstractHandler {
                 PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell(),
                 "Missing Graphviz library",
                 "For using Wrangler code inspection functionalities you must first install the Eclipse GraphViz plugin (and also the original graphviz binaries).\n"
-                        + "Update site: <a src=\"https://download.erlide.org/update/graphviz/\">https://download.erlide.org/update/graphviz/</a>");
+                        + "Update site: <a src=\"https://erlide.org/update/libs/\">https://erlide.org/update/libs/</a>");
 
         m.open();
         return null;

--- a/extras/wrangler/pom.xml
+++ b/extras/wrangler/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.erlide</groupId>
 		<artifactId>org.erlide.parent</artifactId>
-        <version>0.60.4-SNAPSHOT</version>
+        <version>0.61.0-SNAPSHOT</version>
 		<relativePath>../..</relativePath>
 	</parent>
 

--- a/features/org.erlide/feature.xml
+++ b/features/org.erlide/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.erlide"
       label="Erlang language tools IDE"
-      version="0.60.4.qualifier"
+      version="0.61.0.qualifier"
       provider-name="%vendorName"
       plugin="org.erlide.branding"
       image="erlang-64.gif"

--- a/features/org.erlide/feature.xml
+++ b/features/org.erlide/feature.xml
@@ -32,7 +32,7 @@ is available from http://www.eclipse.org/legal/epl-v10.html
    </license>
 
    <url>
-      <update label="Erlide main update site" url="https://download.erlide.org/update/"/>
+      <update label="Erlide main update site" url="https://erlide.org/update/"/>
    </url>
 
    <includes

--- a/features/org.erlide/pom.xml
+++ b/features/org.erlide/pom.xml
@@ -7,12 +7,12 @@
 	<parent>
 		<groupId>org.erlide</groupId>
 		<artifactId>org.erlide.parent</artifactId>
-		<version>0.60.4-SNAPSHOT</version>
+		<version>0.61.0-SNAPSHOT</version>
 		<relativePath>../..</relativePath>
 	</parent>
 
 	<artifactId>org.erlide</artifactId>
-	<version>0.60.4-SNAPSHOT</version>
+	<version>0.61.0-SNAPSHOT</version>
 	<packaging>eclipse-feature</packaging>
 
 </project>

--- a/libs/com.ericsson.otp.jinterface/META-INF/MANIFEST.MF
+++ b/libs/com.ericsson.otp.jinterface/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Erlang OTP JInterface
 Bundle-SymbolicName: com.ericsson.otp.jinterface
 Bundle-ActivationPolicy: lazy
-Bundle-Version: 1.11.0
+Bundle-Version: 1.13.1
 Bundle-Vendor: Erlide project
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: com.ericsson.otp.erlang

--- a/libs/com.ericsson.otp.jinterface/pom.xml
+++ b/libs/com.ericsson.otp.jinterface/pom.xml
@@ -11,7 +11,7 @@
 	</parent>
 
 	<artifactId>com.ericsson.otp.jinterface</artifactId>
-	<version>1.11.0</version>
+	<version>1.13.1</version>
 	<packaging>eclipse-plugin</packaging>
 
 	<build>

--- a/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/GenericQueue.java
+++ b/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/GenericQueue.java
@@ -3,23 +3,25 @@
  *
  * Copyright Ericsson AB 2000-2016. All Rights Reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
- * file except in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under
- * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * %CopyrightEnd%
  */
 package com.ericsson.otp.erlang;
 
 /**
- * This class implements a generic FIFO queue. There is no upper bound on the length of
- * the queue, items are linked.
+ * This class implements a generic FIFO queue. There is no upper bound on the
+ * length of the queue, items are linked.
  */
 
 public class GenericQueue {
@@ -76,7 +78,8 @@ public class GenericQueue {
     }
 
     /**
-     * Retrieve an object from the head of the queue, or block until one arrives.
+     * Retrieve an object from the head of the queue, or block until one
+     * arrives.
      *
      * @return The object at the head of the queue.
      */
@@ -93,18 +96,21 @@ public class GenericQueue {
     }
 
     /**
-     * Retrieve an object from the head of the queue, blocking until one arrives or until
-     * timeout occurs.
+     * Retrieve an object from the head of the queue, blocking until one arrives
+     * or until timeout occurs.
      *
      * @param timeout
-     *            Maximum time to block on queue, in ms. Use 0 to poll the queue.
+     *            Maximum time to block on queue, in ms. Use 0 to poll the
+     *            queue.
      *
      * @exception InterruptedException
      *                if the operation times out.
      *
-     * @return The object at the head of the queue, or null if none arrived in time.
+     * @return The object at the head of the queue, or null if none arrived in
+     *         time.
      */
-    public synchronized Object get(final long timeout) throws InterruptedException {
+    public synchronized Object get(final long timeout)
+            throws InterruptedException {
         if (status == closed) {
             return null;
         }
@@ -154,8 +160,8 @@ public class GenericQueue {
     }
 
     /*
-     * The Bucket class. The queue is implemented as a linked list of Buckets. The
-     * container holds the queued object and a reference to the next Bucket.
+     * The Bucket class. The queue is implemented as a linked list of Buckets.
+     * The container holds the queued object and a reference to the next Bucket.
      */
     class Bucket {
         private Bucket next;

--- a/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/Link.java
+++ b/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/Link.java
@@ -1,17 +1,19 @@
 /*
  * %CopyrightBegin%
  *
- * Copyright Ericsson AB 2000-2016. All Rights Reserved.
+ * Copyright Ericsson AB 2000-2021. All Rights Reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
- * file except in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under
- * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * %CopyrightEnd%
  */
@@ -21,11 +23,14 @@ package com.ericsson.otp.erlang;
 class Link {
     private final OtpErlangPid local;
     private final OtpErlangPid remote;
+    private long unlinking = 0;
     private int hashCodeValue = 0;
 
     public Link(final OtpErlangPid local, final OtpErlangPid remote) {
         this.local = local;
         this.remote = remote;
+        this.unlinking = 0;
+        
     }
 
     public OtpErlangPid local() {
@@ -43,6 +48,14 @@ class Link {
     public boolean equals(final OtpErlangPid alocal, final OtpErlangPid aremote) {
         return local.equals(alocal) && remote.equals(aremote)
                 || local.equals(aremote) && remote.equals(alocal);
+    }
+
+    public long getUnlinking() {
+        return this.unlinking;
+    }
+
+    public void setUnlinking(long unlink_id) {
+        this.unlinking = unlink_id;
     }
 
     @Override

--- a/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/Links.java
+++ b/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/Links.java
@@ -1,17 +1,19 @@
 /*
  * %CopyrightBegin%
  *
- * Copyright Ericsson AB 2000-2016. All Rights Reserved.
+ * Copyright Ericsson AB 2000-2021. All Rights Reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
- * file except in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under
- * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * %CopyrightEnd%
  */
@@ -21,6 +23,7 @@ package com.ericsson.otp.erlang;
 class Links {
     Link[] links;
     int count;
+    int active;
 
     Links() {
         this(10);
@@ -29,31 +32,112 @@ class Links {
     Links(final int initialSize) {
         links = new Link[initialSize];
         count = 0;
+        active = 0;
     }
 
-    synchronized void addLink(final OtpErlangPid local, final OtpErlangPid remote) {
-        if (find(local, remote) == -1) {
+    // Try add link and return if it was added or not...
+    // If already existing it will not be added again.
+    // If force is true it is added even if it is
+    // currently unlinking; otherwise not.
+    synchronized boolean addLink(final OtpErlangPid local,
+                                 final OtpErlangPid remote,
+                                 final boolean force) {
+        int i = find(local, remote);
+        if (i != -1) {
+            if (links[i].getUnlinking() != 0 && force) {
+                links[i].setUnlinking(0);
+                active++;
+                return true;
+            }
+            return false;
+        }
+        else {
             if (count >= links.length) {
                 final Link[] tmp = new Link[count * 2];
                 System.arraycopy(links, 0, tmp, 0, count);
                 links = tmp;
             }
             links[count++] = new Link(local, remote);
+            active++;
+            return true;
         }
     }
 
-    synchronized void removeLink(final OtpErlangPid local, final OtpErlangPid remote) {
+    // Try remove link and return whether it was active or not...
+    synchronized boolean removeLink(final OtpErlangPid local,
+                                    final OtpErlangPid remote) {
         int i;
 
         if ((i = find(local, remote)) != -1) {
+            long unlinking = links[i].getUnlinking();
             count--;
             links[i] = links[count];
             links[count] = null;
+            if (unlinking == 0) {
+                active--;
+                return true;
+            }
         }
+        return false;
     }
 
-    synchronized boolean exists(final OtpErlangPid local, final OtpErlangPid remote) {
-        return find(local, remote) != -1;
+    // Try remove active link and return whether it was removed or not...
+    synchronized boolean removeActiveLink(final OtpErlangPid local,
+                                          final OtpErlangPid remote) {
+        int i;
+
+        if ((i = find(local, remote)) != -1) {
+            long unlinking = links[i].getUnlinking();
+            if (unlinking != 0)
+                return false;
+            count--;
+            active--;
+            links[i] = links[count];
+            links[count] = null;
+            return true;
+        }
+        return false;
+    }
+
+    // Remove link if unlink_id match and return whether it was removed or not...
+    synchronized boolean removeUnlinkingLink(final OtpErlangPid local,
+                                             final OtpErlangPid remote,
+                                             final long unlink_id) {
+        int i;
+
+        if (unlink_id == 0) {
+            return false;
+        }
+
+        if ((i = find(local, remote)) != -1) {
+            long unlinking = links[i].getUnlinking();
+            if (unlinking != unlink_id)
+                return false;
+            count--;
+            links[i] = links[count];
+            links[count] = null;
+            return true;
+        }
+        return false;
+    }
+
+    synchronized boolean setUnlinking(final OtpErlangPid local,
+                                      final OtpErlangPid remote,
+                                      final long unlink_id) {
+        int i;
+
+        if (unlink_id == 0) {
+            return false;
+        }
+
+        if ((i = find(local, remote)) != -1) {
+            if (links[i].getUnlinking() == 0) {
+                links[i].setUnlinking(unlink_id);
+                active--;
+                return true;
+            }
+        }
+        return false;
     }
 
     synchronized int find(final OtpErlangPid local, final OtpErlangPid remote) {
@@ -65,29 +149,15 @@ class Links {
         return -1;
     }
 
-    int count() {
-        return count;
-    }
-
-    /* all local pids get notified about broken connection */
-    synchronized OtpErlangPid[] localPids() {
-        OtpErlangPid[] ret = null;
-        if (count != 0) {
-            ret = new OtpErlangPid[count];
-            for (int i = 0; i < count; i++) {
-                ret[i] = links[i].local();
-            }
-        }
-        return ret;
-    }
-
-    /* all remote pids get notified about failed pid */
     synchronized OtpErlangPid[] remotePids() {
         OtpErlangPid[] ret = null;
-        if (count != 0) {
-            ret = new OtpErlangPid[count];
-            for (int i = 0; i < count; i++) {
-                ret[i] = links[i].remote();
+        if (active != 0) {
+            int a = 0;
+            ret = new OtpErlangPid[active];
+            for (int i = 0; a < active; i++) {
+                if (links[i].getUnlinking() == 0) {
+                    ret[a++] = links[i].remote();
+                }
             }
         }
         return ret;
@@ -107,13 +177,4 @@ class Links {
         return ret;
     }
 
-    /* returns a copy of the link table */
-    synchronized Link[] links() {
-        Link[] ret = null;
-        if (count != 0) {
-            ret = new Link[count];
-            System.arraycopy(links, 0, ret, 0, count);
-        }
-        return ret;
-    }
 }

--- a/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/Makefile
+++ b/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/Makefile
@@ -1,0 +1,138 @@
+# -*-Makefile-*-
+
+#
+# %CopyrightBegin%
+#
+# Copyright Ericsson AB 2000-2022. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# %CopyrightEnd%
+#
+include $(ERL_TOP)/make/target.mk
+
+JAVA_DEST_ROOT = $(ERL_TOP)/lib/jinterface/priv/
+JAVA_SRC_ROOT = $(ERL_TOP)/lib/jinterface/java_src/
+JAVA_CLASS_SUBDIR = com/ericsson/otp/erlang/
+
+include $(ERL_TOP)/make/$(TARGET)/otp.mk
+
+# ----------------------------------------------------
+# Application version
+# ----------------------------------------------------
+include $(ERL_TOP)/lib/jinterface/vsn.mk
+VSN=$(JINTERFACE_VSN)
+
+#
+
+EBINDIR=$(ERL_TOP)/lib/jinterface/ebin
+
+APP_FILE= jinterface.app
+APP_SRC= $(APP_FILE).src
+APP_TARGET= $(EBINDIR)/$(APP_FILE)
+
+APPUP_FILE= jinterface.appup
+APPUP_SRC= $(APPUP_FILE).src
+APPUP_TARGET= $(EBINDIR)/$(APPUP_FILE)
+
+# ----------------------------------------------------
+# Release directory specification
+# ----------------------------------------------------
+RELSYSDIR = $(RELEASE_PATH)/lib/jinterface-$(VSN)
+
+#
+# JAVA macros
+#
+
+# don't add filenames to the Makefile!
+# all java sourcefiles listed in common include file
+include $(ERL_TOP)/lib/jinterface/java_src/$(JAVA_CLASS_SUBDIR)/java_files
+
+TARGET_FILES= $(JAVA_FILES:%=$(JAVA_DEST_ROOT)$(JAVA_CLASS_SUBDIR)%.class) $(APP_TARGET) $(APPUP_TARGET)
+JAVA_SRC= $(JAVA_FILES:%=%.java)
+
+JARFILE= OtpErlang.jar
+
+
+# ----------------------------------------------------
+# Programs and Flags
+# ----------------------------------------------------
+ifeq ($(TARGET),win32)
+    JAR=jar.exe
+else
+    JAR=jar
+endif
+
+CLASSPATH = $(JAVA_SRC_ROOT)
+
+JAVADOCFLAGS=-d $(DOCDIR)
+JAVAFLAGS=-d $(JAVA_DEST_ROOT) 
+JARFLAGS=-cf
+ifneq ($(V),0)
+JARFLAGS=-cfv
+endif
+
+JAVA_OPTIONS = -Xlint -encoding UTF-8
+
+ifeq ($(TESTROOT),)
+RELEASE_PATH="$(ERL_TOP)/release/$(TARGET)"
+else
+RELEASE_PATH=$(TESTROOT)
+endif
+
+
+# ----------------------------------------------------
+# Make Rules
+# ----------------------------------------------------
+
+$(APP_TARGET): $(APP_SRC) $(ERL_TOP)/lib/jinterface/vsn.mk
+	$(vsn_verbose)sed -e 's;%VSN%;$(JINTERFACE_VSN);' $< > $@
+$(APPUP_TARGET): $(APPUP_SRC) $(ERL_TOP)/lib/jinterface/vsn.mk
+	$(vsn_verbose)sed -e 's;%VSN%;$(JINTERFACE_VSN);' $< > $@
+
+$(TYPES): make_dirs $(JAVA_DEST_ROOT)$(JARFILE)
+
+make_dirs:
+	$(V_at)if [ ! -d "$(JAVA_DEST_ROOT)" ];then mkdir "$(JAVA_DEST_ROOT)"; fi
+
+$(JAVA_DEST_ROOT)$(JARFILE): $(TARGET_FILES)
+	@(cd $(JAVA_DEST_ROOT) ; $(JAR) $(JARFLAGS) $(JARFILE) $(JAVA_CLASS_SUBDIR))
+
+clean:
+	$(V_at)rm -f $(TARGET_FILES) *~
+
+docs:
+
+# ----------------------------------------------------
+# Release Targets
+# ----------------------------------------------------
+
+# include $(ERL_TOP)/make/otp_release_targets.mk
+
+release release_docs release_tests release_html:
+	$(V_at)$(MAKE) $(MFLAGS) RELEASE_PATH="$(RELEASE_PATH)" $(TARGET_MAKEFILE)  $@_spec
+
+release_spec: opt
+	$(V_at)$(INSTALL_DIR) "$(RELSYSDIR)/java_src/com/ericsson/otp/erlang"
+	$(V_at)$(INSTALL_DATA) $(JAVA_SRC) "$(RELSYSDIR)/java_src/com/ericsson/otp/erlang"
+	$(V_at)$(INSTALL_DIR) "$(RELSYSDIR)/priv"
+	$(V_at)$(INSTALL_DATA) $(JAVA_DEST_ROOT)$(JARFILE) "$(RELSYSDIR)/priv"
+	$(V_at)$(INSTALL_DIR) "$(RELSYSDIR)/ebin"
+	$(V_at)$(INSTALL_DATA) $(APP_TARGET) "$(RELSYSDIR)/ebin/$(APP_FILE)"
+	$(V_at)$(INSTALL_DATA) $(APPUP_TARGET) "$(RELSYSDIR)/ebin/$(APPUP_FILE)"
+
+release_docs_spec:
+
+xmllint:
+
+# ----------------------------------------------------

--- a/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpAuthException.java
+++ b/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpAuthException.java
@@ -3,24 +3,26 @@
  *
  * Copyright Ericsson AB 2000-2016. All Rights Reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
- * file except in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under
- * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * %CopyrightEnd%
  */
 package com.ericsson.otp.erlang;
 
 /**
- * Exception raised when a node attempts to establish a communication channel when it is
- * not authorized to do so, or when a node sends a message containing an invalid cookie on
- * an established channel.
+ * Exception raised when a node attempts to establish a communication channel
+ * when it is not authorized to do so, or when a node sends a message containing
+ * an invalid cookie on an established channel.
  *
  * @see OtpConnection
  */

--- a/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpCookedConnection.java
+++ b/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpCookedConnection.java
@@ -1,17 +1,19 @@
 /*
  * %CopyrightBegin%
  *
- * Copyright Ericsson AB 2000-2016. All Rights Reserved.
+ * Copyright Ericsson AB 2000-2021. All Rights Reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
- * file except in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under
- * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * %CopyrightEnd%
  */
@@ -21,53 +23,59 @@ import java.io.IOException;
 
 /**
  * <p>
- * Maintains a connection between a Java process and a remote Erlang, Java or C node. The
- * object maintains connection state and allows data to be sent to and received from the
+ * Maintains a connection between a Java process and a remote Erlang, Java or C
+ * node. The object maintains connection state and allows data to be sent to and
+ * received from the peer.
+ * </p>
+ *
+ * <p>
+ * Once a connection is established between the local node and a remote node,
+ * the connection object can be used to send and receive messages between the
+ * nodes.
+ * </p>
+ *
+ * <p>
+ * The various receive methods are all blocking and will return only when a
+ * valid message has been received or an exception is raised.
+ * </p>
+ *
+ * <p>
+ * If an exception occurs in any of the methods in this class, the connection
+ * will be closed and must be reopened in order to resume communication with the
  * peer.
  * </p>
  *
  * <p>
- * Once a connection is established between the local node and a remote node, the
- * connection object can be used to send and receive messages between the nodes.
+ * The message delivery methods in this class deliver directly to
+ * {@link OtpMbox mailboxes} in the {@link OtpNode OtpNode} class.
  * </p>
  *
  * <p>
- * The various receive methods are all blocking and will return only when a valid message
- * has been received or an exception is raised.
- * </p>
- *
- * <p>
- * If an exception occurs in any of the methods in this class, the connection will be
- * closed and must be reopened in order to resume communication with the peer.
- * </p>
- *
- * <p>
- * The message delivery methods in this class deliver directly to {@link OtpMbox
- * mailboxes} in the {@link OtpNode OtpNode} class.
- * </p>
- *
- * <p>
- * It is not possible to create an instance of this class directly. OtpCookedConnection
- * objects are created as needed by the underlying mailbox mechanism.
+ * It is not possible to create an instance of this class directly.
+ * OtpCookedConnection objects are created as needed by the underlying mailbox
+ * mechanism.
  * </p>
  */
 public class OtpCookedConnection extends AbstractConnection {
     protected OtpNode self;
 
     /*
-     * The connection needs to know which local pids have links that pass through here, so
-     * that they can be notified in case of connection failure
+     * The connection needs to know which local pids have links that pass
+     * through here, so that they can be notified in case of connection failure
      */
     protected Links links = null;
 
     /*
-     * Accept an incoming connection from a remote node. Used by {@link OtpSelf#accept()
-     * OtpSelf.accept()} to create a connection based on data received when handshaking
-     * with the peer node, when the remote node is the connection intitiator.
+     * Accept an incoming connection from a remote node. Used by {@link
+     * OtpSelf#accept() OtpSelf.accept()} to create a connection based on data
+     * received when handshaking with the peer node, when the remote node is the
+     * connection intitiator.
      *
-     * @exception java.io.IOException if it was not possible to connect to the peer.
+     * @exception java.io.IOException if it was not possible to connect to the
+     * peer.
      *
-     * @exception OtpAuthException if handshake resulted in an authentication error
+     * @exception OtpAuthException if handshake resulted in an authentication
+     * error
      */
     // package scope
     OtpCookedConnection(final OtpNode self, final OtpTransport s)
@@ -81,9 +89,11 @@ public class OtpCookedConnection extends AbstractConnection {
     /*
      * Intiate and open a connection to a remote node.
      *
-     * @exception java.io.IOException if it was not possible to connect to the peer.
+     * @exception java.io.IOException if it was not possible to connect to the
+     * peer.
      *
-     * @exception OtpAuthException if handshake resulted in an authentication error.
+     * @exception OtpAuthException if handshake resulted in an authentication
+     * error.
      */
     // package scope
     OtpCookedConnection(final OtpNode self, final OtpPeer other)
@@ -98,12 +108,13 @@ public class OtpCookedConnection extends AbstractConnection {
     @Override
     public void deliver(final Exception e) {
         self.deliverError(this, e);
+        return;
     }
 
     /*
-     * pass the message to the node for final delivery. Note that the connection itself
-     * needs to know about links (in case of connection failure), so we snoop for
-     * link/unlink too here.
+     * pass the message to the node for final delivery. Note that the connection
+     * itself needs to know about links (in case of connection failure), so we
+     * snoop for link/unlink too here.
      */
     @Override
     public void deliver(final OtpMsg msg) {
@@ -111,9 +122,7 @@ public class OtpCookedConnection extends AbstractConnection {
 
         switch (msg.type()) {
         case OtpMsg.linkTag:
-            if (delivered) {
-                links.addLink(msg.getRecipientPid(), msg.getSenderPid());
-            } else {
+            if (!delivered) {
                 try {
                     // no such pid - send exit to sender
                     super.sendExit(msg.getRecipientPid(), msg.getSenderPid(),
@@ -122,34 +131,30 @@ public class OtpCookedConnection extends AbstractConnection {
                 }
             }
             break;
-
-        case OtpMsg.unlinkTag:
-        case OtpMsg.exitTag:
-            links.removeLink(msg.getRecipientPid(), msg.getSenderPid());
-            break;
-
-        case OtpMsg.exit2Tag:
+        default:
             break;
         }
+
+        return;
     }
 
     /*
      * send to pid
      */
     @SuppressWarnings("resource")
-    void send(final OtpErlangPid from, final OtpErlangPid dest, final OtpErlangObject msg)
-            throws IOException {
+    void send(final OtpErlangPid from, final OtpErlangPid dest,
+            final OtpErlangObject msg) throws IOException {
         // encode and send the message
         sendBuf(from, dest, new OtpOutputStream(msg));
     }
 
     /*
-     * send to remote name dest is recipient's registered name, the nodename is implied by
-     * the choice of connection.
+     * send to remote name dest is recipient's registered name, the nodename is
+     * implied by the choice of connection.
      */
     @SuppressWarnings("resource")
-    void send(final OtpErlangPid from, final String dest, final OtpErlangObject msg)
-            throws IOException {
+    void send(final OtpErlangPid from, final String dest,
+            final OtpErlangObject msg) throws IOException {
         // encode and send the message
         sendBuf(from, dest, new OtpOutputStream(msg));
     }
@@ -177,7 +182,7 @@ public class OtpCookedConnection extends AbstractConnection {
     }
 
     /*
-     * this one called explicitely by user code => use exit2
+     * this one called explicitly by user code => use exit2
      */
     void exit2(final OtpErlangPid from, final OtpErlangPid to,
             final OtpErlangObject reason) {
@@ -187,33 +192,42 @@ public class OtpCookedConnection extends AbstractConnection {
         }
     }
 
-    /*
-     * snoop for outgoing links and update own table
-     */
-    synchronized void link(final OtpErlangPid from, final OtpErlangPid to)
-            throws OtpErlangExit {
+    void link(final OtpErlangPid from, final OtpErlangPid to)
+        throws OtpErlangExit {
         try {
             super.sendLink(from, to);
-            links.addLink(from, to);
         } catch (final IOException e) {
             throw new OtpErlangExit("noproc", to);
         }
     }
 
-    /*
-     * snoop for outgoing unlinks and update own table
-     */
-    synchronized void unlink(final OtpErlangPid from, final OtpErlangPid to) {
-        links.removeLink(from, to);
+    void unlink(final OtpErlangPid from, final OtpErlangPid to, final long unlink_id) {
         try {
-            super.sendUnlink(from, to);
+            super.sendUnlink(from, to , unlink_id);
         } catch (final IOException e) {
         }
     }
 
+    void unlink_ack(final OtpErlangPid from, final OtpErlangPid to, final long unlink_id) {
+        try {
+            super.sendUnlinkAck(from, to , unlink_id);
+        } catch (final IOException e) {
+        }
+    }
+
+    synchronized void node_link(OtpErlangPid local, OtpErlangPid remote, boolean add)
+    {
+        if (add) {
+                links.addLink(local, remote, true);
+        }
+        else {
+            links.removeLink(local, remote);
+        }
+    }
+
     /*
-     * When the connection fails - send exit to all local pids with links through this
-     * connection
+     * When the connection fails - send exit to all local pids with links
+     * through this connection
      */
     synchronized void breakLinks() {
         if (links != null) {
@@ -224,8 +238,8 @@ public class OtpCookedConnection extends AbstractConnection {
 
                 for (int i = 0; i < len; i++) {
                     // send exit "from" remote pids to local ones
-                    self.deliver(new OtpMsg(OtpMsg.exitTag, l[i].remote(), l[i].local(),
-                            new OtpErlangAtom("noconnection")));
+                    self.deliver(new OtpMsg(OtpMsg.exitTag, l[i].remote(), l[i]
+                            .local(), new OtpErlangAtom("noconnection")));
                 }
             }
         }

--- a/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpEpmd.java
+++ b/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpEpmd.java
@@ -1,17 +1,19 @@
 /*
  * %CopyrightBegin%
  *
- * Copyright Ericsson AB 2000-2016. All Rights Reserved.
+ * Copyright Ericsson AB 2000-2021. All Rights Reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
- * file except in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under
- * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * %CopyrightEnd%
  */
@@ -22,23 +24,24 @@ import java.io.IOException;
 import java.net.InetAddress;
 
 /**
- * Provides methods for registering, unregistering and looking up nodes with the Erlang
- * portmapper daemon (Epmd). For each registered node, Epmd maintains information about
- * the port on which incoming connections are accepted, as well as which versions of the
- * Erlang communication protocol the node supports.
+ * Provides methods for registering, unregistering and looking up nodes with the
+ * Erlang portmapper daemon (Epmd). For each registered node, Epmd maintains
+ * information about the port on which incoming connections are accepted, as
+ * well as which versions of the Erlang communication protocol the node
+ * supports.
  *
  * <p>
- * Nodes wishing to contact other nodes must first request information from Epmd before a
- * connection can be set up, however this is done automatically by
+ * Nodes wishing to contact other nodes must first request information from Epmd
+ * before a connection can be set up, however this is done automatically by
  * {@link OtpSelf#connect(OtpPeer) OtpSelf.connect()} when necessary.
  *
  * <p>
  * The methods {@link #publishPort(OtpLocalNode) publishPort()} and
- * {@link #unPublishPort(OtpLocalNode) unPublishPort()} will fail if an Epmd process is
- * not running on the localhost. Additionally {@link #lookupPort(AbstractNode)
- * lookupPort()} will fail if there is no Epmd process running on the host where the
- * specified node is running. See the Erlang documentation for information about starting
- * Epmd.
+ * {@link #unPublishPort(OtpLocalNode) unPublishPort()} will fail if an Epmd
+ * process is not running on the localhost. Additionally
+ * {@link #lookupPort(AbstractNode) lookupPort()} will fail if there is no Epmd
+ * process running on the host where the specified node is running. See the
+ * Erlang documentation for information about starting Epmd.
  *
  * <p>
  * This class contains only static methods, there are no constructors.
@@ -81,7 +84,8 @@ public class OtpEpmd {
 
     static {
         // debug this connection?
-        final String trace = System.getProperties().getProperty("OtpConnection.trace");
+        final String trace = System.getProperties().getProperty(
+                "OtpConnection.trace");
         try {
             if (trace != null) {
                 traceLevel = Integer.valueOf(trace).intValue();
@@ -97,9 +101,9 @@ public class OtpEpmd {
     }
 
     /**
-     * Set the port number to be used to contact the epmd process. Only needed when the
-     * default port is not desired and system environment variable ERL_EPMD_PORT cannot be
-     * read (applet).
+     * Set the port number to be used to contact the epmd process. Only needed
+     * when the default port is not desired and system environment variable
+     * ERL_EPMD_PORT cannot be read (applet).
      */
     public static void useEpmdPort(final int port) {
         EpmdPort.set(port);
@@ -108,8 +112,8 @@ public class OtpEpmd {
     /**
      * Determine what port a node listens for incoming connections on.
      *
-     * @return the listen port for the specified node, or 0 if the node was not registered
-     *         with Epmd.
+     * @return the listen port for the specified node, or 0 if the node was not
+     *         registered with Epmd.
      *
      * @exception java.io.IOException
      *                if there was no response from the name server.
@@ -119,19 +123,21 @@ public class OtpEpmd {
     }
 
     /**
-     * Register with Epmd, so that other nodes are able to find and connect to it.
+     * Register with Epmd, so that other nodes are able to find and connect to
+     * it.
      *
      * @param node
      *            the server node that should be registered with Epmd.
      *
-     * @return true if the operation was successful. False if the node was already
-     *         registered.
+     * @return true if the operation was successful. False if the node was
+     *         already registered.
      *
      * @exception java.io.IOException
      *                if there was no response from the name server.
      */
-    public static boolean publishPort(final OtpLocalNode node) throws IOException {
-        OtpTransport s;
+    public static boolean publishPort(final OtpLocalNode node)
+            throws IOException {
+        OtpTransport s = null;
 
         s = r4_publish(node);
 
@@ -144,7 +150,8 @@ public class OtpEpmd {
     // Caller should close his epmd socket as well.
     // This method is pretty forgiving...
     /**
-     * Unregister from Epmd. Other nodes wishing to connect will no longer be able to.
+     * Unregister from Epmd. Other nodes wishing to connect will no longer be
+     * able to.
      *
      * <p>
      * This method does not report any failures.
@@ -162,7 +169,8 @@ public class OtpEpmd {
             obuf.writeToAndFlush(s.getOutputStream());
             // don't even wait for a response (is there one?)
             if (traceLevel >= traceThreshold) {
-                System.out.println("-> UNPUBLISH " + node + " port=" + node.port());
+                System.out.println("-> UNPUBLISH " + node + " port="
+                        + node.port());
                 System.out.println("<- OK (assumed)");
             }
         } catch (final Exception e) {/* ignore all failures */
@@ -177,7 +185,8 @@ public class OtpEpmd {
         }
     }
 
-    private static int r4_lookupPort(final AbstractNode node) throws IOException {
+    private static int r4_lookupPort(final AbstractNode node)
+            throws IOException {
         int port = 0;
         OtpTransport s = null;
 
@@ -209,8 +218,8 @@ public class OtpEpmd {
 
             if (n < 0) {
                 s.close();
-                throw new IOException("Nameserver not responding on " + node.host()
-                        + " when looking up " + node.alive());
+                throw new IOException("Nameserver not responding on "
+                        + node.host() + " when looking up " + node.alive());
             }
 
             @SuppressWarnings("resource")
@@ -262,13 +271,14 @@ public class OtpEpmd {
     }
 
     /*
-     * this function will get an exception if it tries to talk to a very old epmd, or if
-     * something else happens that it cannot forsee. In both cases we return an exception.
-     * We no longer support r3, so the exception is fatal. If we manage to successfully
-     * communicate with an r4 epmd, we return either the socket, or null, depending on the
-     * result.
+     * this function will get an exception if it tries to talk to a very old
+     * epmd, or if something else happens that it cannot forsee. In both cases
+     * we return an exception. We no longer support r3, so the exception is
+     * fatal. If we manage to successfully communicate with an r4 epmd, we
+     * return either the socket, or null, depending on the result.
      */
-    private static OtpTransport r4_publish(final OtpLocalNode node) throws IOException {
+    private static OtpTransport r4_publish(final OtpLocalNode node)
+            throws IOException {
         OtpTransport s = null;
 
         try {
@@ -295,7 +305,8 @@ public class OtpEpmd {
             obuf.writeToAndFlush(s.getOutputStream());
 
             if (traceLevel >= traceThreshold) {
-                System.out.println("-> PUBLISH (r4) " + node + " port=" + node.port());
+                System.out.println("-> PUBLISH (r4) " + node + " port="
+                        + node.port());
             }
 
             // get reply
@@ -304,8 +315,8 @@ public class OtpEpmd {
 
             if (n < 0) {
                 s.close();
-                throw new IOException("Nameserver not responding on " + node.host()
-                        + " when publishing " + node.alive());
+                throw new IOException("Nameserver not responding on "
+                        + node.host() + " when publishing " + node.alive());
             }
 
             @SuppressWarnings("resource")
@@ -315,8 +326,8 @@ public class OtpEpmd {
             if (response == ALIVE2_RESP || response == ALIVE2_X_RESP) {
                 final int result = ibuf.read1();
                 if (result == 0) {
-                    node.creation = response == ALIVE2_RESP ? ibuf.read2BE()
-                            : ibuf.read4BE();
+                    node.setCreation(response == ALIVE2_RESP
+                                     ? ibuf.read2BE() : ibuf.read4BE());
                     if (traceLevel >= traceThreshold) {
                         System.out.println("<- OK");
                     }
@@ -347,15 +358,17 @@ public class OtpEpmd {
     }
 
     public static String[] lookupNames() throws IOException {
-        return lookupNames(InetAddress.getByName(null), new OtpSocketTransportFactory());
+        return lookupNames(InetAddress.getByName(null),
+                new OtpSocketTransportFactory());
     }
 
-    public static String[] lookupNames(final OtpTransportFactory transportFactory)
-            throws IOException {
+    public static String[] lookupNames(
+            final OtpTransportFactory transportFactory) throws IOException {
         return lookupNames(InetAddress.getByName(null), transportFactory);
     }
 
-    public static String[] lookupNames(final InetAddress address) throws IOException {
+    public static String[] lookupNames(final InetAddress address)
+            throws IOException {
         return lookupNames(address, new OtpSocketTransportFactory());
     }
 
@@ -410,12 +423,14 @@ public class OtpEpmd {
             if (traceLevel >= traceThreshold) {
                 System.out.println("<- (no response)");
             }
-            throw new IOException("Nameserver not responding when requesting names");
+            throw new IOException(
+                    "Nameserver not responding when requesting names");
         } catch (final OtpErlangDecodeException e) {
             if (traceLevel >= traceThreshold) {
                 System.out.println("<- (invalid response)");
             }
-            throw new IOException("Nameserver not responding when requesting names");
+            throw new IOException(
+                    "Nameserver not responding when requesting names");
         }
     }
 

--- a/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpErlangAtom.java
+++ b/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpErlangAtom.java
@@ -1,31 +1,34 @@
 /*
  * %CopyrightBegin%
  *
- * Copyright Ericsson AB 2000-2016. All Rights Reserved.
+ * Copyright Ericsson AB 2000-2022. All Rights Reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
- * file except in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under
- * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * %CopyrightEnd%
  */
 package com.ericsson.otp.erlang;
 
 /**
- * Provides a Java representation of Erlang atoms. Atoms can be created from strings whose
- * length is not more than {@link #maxAtomLength maxAtomLength} characters.
+ * Provides a Java representation of Erlang atoms. Atoms can be created from
+ * strings whose length is not more than {@link #maxAtomLength maxAtomLength}
+ * characters.
  */
 public class OtpErlangAtom extends OtpErlangObject {
     // don't change this!
     private static final long serialVersionUID = -3204386396807876641L;
 
-    /** The maximun allowed length of an atom, in characters */
+    /** The maximum allowed length of an atom, in characters */
     public static final int maxAtomLength = 0xff; // one byte length
 
     private final String atom;
@@ -37,8 +40,8 @@ public class OtpErlangAtom extends OtpErlangObject {
      *            the string to create the atom from.
      *
      * @exception java.lang.IllegalArgumentException
-     *                if the string is null or contains more than {@link #maxAtomLength
-     *                maxAtomLength} characters.
+     *                if the string is null or contains more than
+     *                {@link #maxAtomLength maxAtomLength} characters.
      */
     public OtpErlangAtom(final String atom) {
         if (atom == null) {
@@ -46,23 +49,25 @@ public class OtpErlangAtom extends OtpErlangObject {
         }
 
         if (atom.codePointCount(0, atom.length()) > maxAtomLength) {
-            throw new java.lang.IllegalArgumentException(
-                    "Atom may not exceed " + maxAtomLength + " characters: " + atom);
+            throw new java.lang.IllegalArgumentException("Atom may not exceed "
+                    + maxAtomLength + " characters: " + atom);
         }
         this.atom = atom;
     }
 
     /**
-     * Create an atom from a stream containing an atom encoded in Erlang external format.
+     * Create an atom from a stream containing an atom encoded in Erlang
+     * external format.
      *
      * @param buf
      *            the stream containing the encoded atom.
      *
      * @exception OtpErlangDecodeException
-     *                if the buffer does not contain a valid external representation of an
-     *                Erlang atom.
+     *                if the buffer does not contain a valid external
+     *                representation of an Erlang atom.
      */
-    public OtpErlangAtom(final OtpInputStream buf) throws OtpErlangDecodeException {
+    public OtpErlangAtom(final OtpInputStream buf)
+            throws OtpErlangDecodeException {
         atom = buf.read_atom();
     }
 
@@ -76,8 +81,8 @@ public class OtpErlangAtom extends OtpErlangObject {
     /**
      * Get the actual string contained in this object.
      *
-     * @return the raw string contained in this object, without regard to Erlang quoting
-     *         rules.
+     * @return the raw string contained in this object, without regard to Erlang
+     *         quoting rules.
      *
      * @see #toString
      */
@@ -88,9 +93,9 @@ public class OtpErlangAtom extends OtpErlangObject {
     /**
      * The boolean value of this atom.
      *
-     * @return the value of this atom expressed as a boolean value. If the atom consists
-     *         of the characters "true" (independent of case) the value will be true. For
-     *         any other values, the value will be false.
+     * @return the value of this atom expressed as a boolean value. If the atom
+     *         consists of the characters "true" (independent of case) the value
+     *         will be true. For any other values, the value will be false.
      *
      */
     public boolean booleanValue() {
@@ -98,9 +103,10 @@ public class OtpErlangAtom extends OtpErlangObject {
     }
 
     /**
-     * Get the printname of the atom represented by this object. The difference between
-     * this method and {link #atomValue atomValue()} is that the printname is quoted and
-     * escaped where necessary, according to the Erlang rules for atom naming.
+     * Get the printname of the atom represented by this object. The difference
+     * between this method and {link #atomValue atomValue()} is that the
+     * printname is quoted and escaped where necessary, according to the Erlang
+     * rules for atom naming.
      *
      * @return the printname representation of this atom object.
      *
@@ -189,8 +195,9 @@ public class OtpErlangAtom extends OtpErlangObject {
     }
 
     /*
-     * Get the atom string, with special characters escaped. Note that this function
-     * currently does not consider any characters above 127 to be printable.
+     * Get the atom string, with special characters escaped. Note that this
+     * function currently does not consider any characters above 127 to be
+     * printable.
      */
     private String escapeSpecialChars(final String s) {
         char c;
@@ -201,9 +208,9 @@ public class OtpErlangAtom extends OtpErlangObject {
             c = s.charAt(i);
 
             /*
-             * note that some of these escape sequences are unique to Erlang, which is why
-             * the corresponding 'case' values use octal. The resulting string is, of
-             * course, in Erlang format.
+             * note that some of these escape sequences are unique to Erlang,
+             * which is why the corresponding 'case' values use octal. The
+             * resulting string is, of course, in Erlang format.
              */
 
             switch (c) {

--- a/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpErlangBinary.java
+++ b/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpErlangBinary.java
@@ -3,23 +3,25 @@
  *
  * Copyright Ericsson AB 2000-2016. All Rights Reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
- * file except in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under
- * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * %CopyrightEnd%
  */
 package com.ericsson.otp.erlang;
 
 /**
- * Provides a Java representation of Erlang binaries. Anything that can be represented as
- * a sequence of bytes can be made into an Erlang binary.
+ * Provides a Java representation of Erlang binaries. Anything that can be
+ * represented as a sequence of bytes can be made into an Erlang binary.
  */
 public class OtpErlangBinary extends OtpErlangBitstr {
     // don't change this!
@@ -36,17 +38,18 @@ public class OtpErlangBinary extends OtpErlangBitstr {
     }
 
     /**
-     * Create a binary from a stream containing a binary encoded in Erlang external
-     * format.
+     * Create a binary from a stream containing a binary encoded in Erlang
+     * external format.
      *
      * @param buf
      *            the stream containing the encoded binary.
      *
      * @exception OtpErlangDecodeException
-     *                if the buffer does not contain a valid external representation of an
-     *                Erlang binary.
+     *                if the buffer does not contain a valid external
+     *                representation of an Erlang binary.
      */
-    public OtpErlangBinary(final OtpInputStream buf) throws OtpErlangDecodeException {
+    public OtpErlangBinary(final OtpInputStream buf)
+            throws OtpErlangDecodeException {
         super(new byte[0]);
         bin = buf.read_binary();
         pad_bits = 0;
@@ -67,7 +70,8 @@ public class OtpErlangBinary extends OtpErlangBitstr {
      * Convert this binary to the equivalent Erlang external representation.
      *
      * @param buf
-     *            an output stream to which the encoded binary should be written.
+     *            an output stream to which the encoded binary should be
+     *            written.
      */
     @Override
     public void encode(final OtpOutputStream buf) {

--- a/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpErlangBitstr.java
+++ b/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpErlangBitstr.java
@@ -3,15 +3,17 @@
  *
  * Copyright Ericsson AB 2007-2016. All Rights Reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
- * file except in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under
- * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * %CopyrightEnd%
  */
@@ -21,9 +23,9 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 
 /**
- * Provides a Java representation of Erlang bitstrs. An Erlang bitstr is an Erlang binary
- * with a length not an integral number of bytes (8-bit). Anything can be represented as a
- * sequence of bytes can be made into an Erlang bitstr.
+ * Provides a Java representation of Erlang bitstrs. An Erlang bitstr is an
+ * Erlang binary with a length not an integral number of bytes (8-bit). Anything
+ * can be represented as a sequence of bytes can be made into an Erlang bitstr.
  */
 public class OtpErlangBitstr extends OtpErlangObject {
     // don't change this!
@@ -62,10 +64,12 @@ public class OtpErlangBitstr extends OtpErlangObject {
 
     private void check_bitstr(final byte[] abin, final int a_pad_bits) {
         if (a_pad_bits < 0 || 7 < a_pad_bits) {
-            throw new java.lang.IllegalArgumentException("Padding must be in range 0..7");
+            throw new java.lang.IllegalArgumentException(
+                    "Padding must be in range 0..7");
         }
         if (a_pad_bits != 0 && abin.length == 0) {
-            throw new java.lang.IllegalArgumentException("Padding on zero length bitstr");
+            throw new java.lang.IllegalArgumentException(
+                    "Padding on zero length bitstr");
         }
         if (abin.length != 0) {
             // Make sure padding is zero
@@ -74,17 +78,18 @@ public class OtpErlangBitstr extends OtpErlangObject {
     }
 
     /**
-     * Create a bitstr from a stream containing a bitstr encoded in Erlang external
-     * format.
+     * Create a bitstr from a stream containing a bitstr encoded in Erlang
+     * external format.
      *
      * @param buf
      *            the stream containing the encoded bitstr.
      *
      * @exception OtpErlangDecodeException
-     *                if the buffer does not contain a valid external representation of an
-     *                Erlang bitstr.
+     *                if the buffer does not contain a valid external
+     *                representation of an Erlang bitstr.
      */
-    public OtpErlangBitstr(final OtpInputStream buf) throws OtpErlangDecodeException {
+    public OtpErlangBitstr(final OtpInputStream buf)
+            throws OtpErlangDecodeException {
         final int pbs[] = { 0 }; // This is ugly just to get a value-result
         // parameter
         bin = buf.read_bitstr(pbs);
@@ -110,7 +115,8 @@ public class OtpErlangBitstr extends OtpErlangObject {
         }
     }
 
-    private static byte[] toByteArray(final Object o) throws java.io.IOException {
+    private static byte[] toByteArray(final Object o)
+            throws java.io.IOException {
 
         if (o == null) {
             return null;
@@ -118,7 +124,8 @@ public class OtpErlangBitstr extends OtpErlangObject {
 
         /* need to synchronize use of the shared baos */
         final java.io.ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        final java.io.ObjectOutputStream oos = new java.io.ObjectOutputStream(baos);
+        final java.io.ObjectOutputStream oos = new java.io.ObjectOutputStream(
+                baos);
 
         oos.writeObject(o);
         oos.flush();
@@ -134,7 +141,8 @@ public class OtpErlangBitstr extends OtpErlangObject {
         try {
             final java.io.ByteArrayInputStream bais = new java.io.ByteArrayInputStream(
                     buf);
-            final java.io.ObjectInputStream ois = new java.io.ObjectInputStream(bais);
+            final java.io.ObjectInputStream ois = new java.io.ObjectInputStream(
+                    bais);
             return ois.readObject();
         } catch (final java.lang.ClassNotFoundException e) {
         } catch (final java.io.IOException e) {
@@ -144,8 +152,8 @@ public class OtpErlangBitstr extends OtpErlangObject {
     }
 
     /**
-     * Get the byte array from a bitstr, padded with zero bits in the little end of the
-     * last byte.
+     * Get the byte array from a bitstr, padded with zero bits in the little end
+     * of the last byte.
      *
      * @return the byte array containing the bytes for this bitstr.
      */
@@ -154,7 +162,8 @@ public class OtpErlangBitstr extends OtpErlangObject {
     }
 
     /**
-     * Get the size in whole bytes of the bitstr, rest bits in the last byte not counted.
+     * Get the size in whole bytes of the bitstr, rest bits in the last byte not
+     * counted.
      *
      * @return the number of bytes contained in the bintstr.
      */
@@ -169,8 +178,8 @@ public class OtpErlangBitstr extends OtpErlangObject {
     }
 
     /**
-     * Get the number of pad bits in the last byte of the bitstr. The pad bits are zero
-     * and in the little end.
+     * Get the number of pad bits in the last byte of the bitstr. The pad bits
+     * are zero and in the little end.
      *
      * @return the number of pad bits in the bitstr.
      */
@@ -179,12 +188,12 @@ public class OtpErlangBitstr extends OtpErlangObject {
     }
 
     /**
-     * Get the java Object from the bitstr. If the bitstr contains a serialized Java
-     * object, then this method will recreate the object.
+     * Get the java Object from the bitstr. If the bitstr contains a serialized
+     * Java object, then this method will recreate the object.
      *
      *
-     * @return the java Object represented by this bitstr, or null if the bitstr does not
-     *         represent a Java Object.
+     * @return the java Object represented by this bitstr, or null if the bitstr
+     *         does not represent a Java Object.
      */
     public Object getObject() {
         if (pad_bits != 0) {
@@ -194,9 +203,9 @@ public class OtpErlangBitstr extends OtpErlangObject {
     }
 
     /**
-     * Get the string representation of this bitstr object. A bitstr is printed as
-     * #Bin&lt;N&gt;, where N is the number of bytes contained in the object or
-     * #bin&lt;N-M&gt; if there are M pad bits.
+     * Get the string representation of this bitstr object. A bitstr is printed
+     * as #Bin&lt;N&gt;, where N is the number of bytes contained in the object
+     * or #bin&lt;N-M&gt; if there are M pad bits.
      *
      * @return the Erlang string representation of this bitstr.
      */
@@ -215,7 +224,8 @@ public class OtpErlangBitstr extends OtpErlangObject {
      * Convert this bitstr to the equivalent Erlang external representation.
      *
      * @param buf
-     *            an output stream to which the encoded bitstr should be written.
+     *            an output stream to which the encoded bitstr should be
+     *            written.
      */
     @Override
     public void encode(final OtpOutputStream buf) {
@@ -223,8 +233,8 @@ public class OtpErlangBitstr extends OtpErlangObject {
     }
 
     /**
-     * Determine if two bitstrs are equal. Bitstrs are equal if they have the same byte
-     * length and tail length, and the array of bytes is identical.
+     * Determine if two bitstrs are equal. Bitstrs are equal if they have the
+     * same byte length and tail length, and the array of bytes is identical.
      *
      * @param o
      *            the bitstr to compare to.

--- a/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpErlangBoolean.java
+++ b/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpErlangBoolean.java
@@ -3,23 +3,25 @@
  *
  * Copyright Ericsson AB 2000-2016. All Rights Reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
- * file except in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under
- * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * %CopyrightEnd%
  */
 package com.ericsson.otp.erlang;
 
 /**
- * Provides a Java representation of Erlang booleans, which are special cases of atoms
- * with values 'true' and 'false'.
+ * Provides a Java representation of Erlang booleans, which are special cases of
+ * atoms with values 'true' and 'false'.
  */
 public class OtpErlangBoolean extends OtpErlangAtom {
     // don't change this!
@@ -36,16 +38,17 @@ public class OtpErlangBoolean extends OtpErlangAtom {
     }
 
     /**
-     * Create a boolean from a stream containing an atom encoded in Erlang external
-     * format. The value of the boolean will be true if the atom represented by the stream
-     * is "true" without regard to case. For other atom values, the boolean will have the
-     * value false.
+     * Create a boolean from a stream containing an atom encoded in Erlang
+     * external format. The value of the boolean will be true if the atom
+     * represented by the stream is "true" without regard to case. For other
+     * atom values, the boolean will have the value false.
      *
      * @exception OtpErlangDecodeException
-     *                if the buffer does not contain a valid external representation of an
-     *                Erlang atom.
+     *                if the buffer does not contain a valid external
+     *                representation of an Erlang atom.
      */
-    public OtpErlangBoolean(final OtpInputStream buf) throws OtpErlangDecodeException {
+    public OtpErlangBoolean(final OtpInputStream buf)
+            throws OtpErlangDecodeException {
         super(buf);
     }
 }

--- a/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpErlangByte.java
+++ b/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpErlangByte.java
@@ -3,15 +3,17 @@
  *
  * Copyright Ericsson AB 2000-2016. All Rights Reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
- * file except in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under
- * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * %CopyrightEnd%
  */
@@ -35,15 +37,15 @@ public class OtpErlangByte extends OtpErlangLong {
     }
 
     /**
-     * Create an Erlang integer from a stream containing an integer encoded in Erlang
-     * external format.
+     * Create an Erlang integer from a stream containing an integer encoded in
+     * Erlang external format.
      *
      * @param buf
      *            the stream containing the encoded value.
      *
      * @exception OtpErlangDecodeException
-     *                if the buffer does not contain a valid external representation of an
-     *                Erlang integer.
+     *                if the buffer does not contain a valid external
+     *                representation of an Erlang integer.
      *
      * @exception OtpErlangRangeException
      *                if the value is too large to be represented as a byte.

--- a/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpErlangChar.java
+++ b/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpErlangChar.java
@@ -3,15 +3,17 @@
  *
  * Copyright Ericsson AB 2000-2016. All Rights Reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
- * file except in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under
- * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * %CopyrightEnd%
  */
@@ -35,15 +37,15 @@ public class OtpErlangChar extends OtpErlangLong {
     }
 
     /**
-     * Create an Erlang integer from a stream containing an integer encoded in Erlang
-     * external format.
+     * Create an Erlang integer from a stream containing an integer encoded in
+     * Erlang external format.
      *
      * @param buf
      *            the stream containing the encoded value.
      *
      * @exception OtpErlangDecodeException
-     *                if the buffer does not contain a valid external representation of an
-     *                Erlang integer.
+     *                if the buffer does not contain a valid external
+     *                representation of an Erlang integer.
      *
      * @exception OtpErlangRangeException
      *                if the value is too large to be represented as a char.

--- a/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpErlangDecodeException.java
+++ b/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpErlangDecodeException.java
@@ -3,23 +3,26 @@
  *
  * Copyright Ericsson AB 2000-2016. All Rights Reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
- * file except in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under
- * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * %CopyrightEnd%
  */
 package com.ericsson.otp.erlang;
 
 /**
- * Exception raised when an attempt is made to create an Erlang term by decoding a
- * sequence of bytes that does not represent the type of term that was requested.
+ * Exception raised when an attempt is made to create an Erlang term by decoding
+ * a sequence of bytes that does not represent the type of term that was
+ * requested.
  *
  * @see OtpInputStream
  */

--- a/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpErlangDouble.java
+++ b/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpErlangDouble.java
@@ -1,26 +1,29 @@
 /*
  * %CopyrightBegin%
  *
- * Copyright Ericsson AB 2000-2016. All Rights Reserved.
+ * Copyright Ericsson AB 2000-2021. All Rights Reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
- * file except in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under
- * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * %CopyrightEnd%
  */
 package com.ericsson.otp.erlang;
 
 /**
- * Provides a Java representation of Erlang floats and doubles. Erlang defines only one
- * floating point numeric type, however this class and its subclass {@link OtpErlangFloat}
- * are used to provide representations corresponding to the Java types Double and Float.
+ * Provides a Java representation of Erlang floats and doubles. Erlang defines
+ * only one floating point numeric type, however this class and its subclass
+ * {@link OtpErlangFloat} are used to provide representations corresponding to
+ * the Java types Double and Float.
  */
 public class OtpErlangDouble extends OtpErlangObject {
     // don't change this!
@@ -36,17 +39,18 @@ public class OtpErlangDouble extends OtpErlangObject {
     }
 
     /**
-     * Create an Erlang float from a stream containing a double encoded in Erlang external
-     * format.
+     * Create an Erlang float from a stream containing a double encoded in
+     * Erlang external format.
      *
      * @param buf
      *            the stream containing the encoded value.
      *
      * @exception OtpErlangDecodeException
-     *                if the buffer does not contain a valid external representation of an
-     *                Erlang float.
+     *                if the buffer does not contain a valid external
+     *                representation of an Erlang float.
      */
-    public OtpErlangDouble(final OtpInputStream buf) throws OtpErlangDecodeException {
+    public OtpErlangDouble(final OtpInputStream buf)
+            throws OtpErlangDecodeException {
         d = buf.read_double();
     }
 
@@ -99,7 +103,8 @@ public class OtpErlangDouble extends OtpErlangObject {
     }
 
     /**
-     * Determine if two floats are equal. Floats are equal if they contain the same value.
+     * Determine if two floats are equal. Floats are equal if they contain the
+     * same value.
      *
      * @param o
      *            the float to compare to.
@@ -118,7 +123,7 @@ public class OtpErlangDouble extends OtpErlangObject {
 
     @Override
     protected int doHashCode() {
-        final Double v = new Double(d);
+        final Double v = Double.valueOf(d);
         return v.hashCode();
     }
 }

--- a/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpErlangException.java
+++ b/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpErlangException.java
@@ -3,15 +3,17 @@
  *
  * Copyright Ericsson AB 2000-2016. All Rights Reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
- * file except in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under
- * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * %CopyrightEnd%
  */
@@ -27,6 +29,7 @@ public class OtpErlangException extends OtpException {
      * Provides no message.
      */
     public OtpErlangException() {
+        super();
     }
 
     /**

--- a/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpErlangExit.java
+++ b/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpErlangExit.java
@@ -3,23 +3,25 @@
  *
  * Copyright Ericsson AB 2000-2016. All Rights Reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
- * file except in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under
- * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * %CopyrightEnd%
  */
 package com.ericsson.otp.erlang;
 
 /**
- * Exception raised when a communication channel is broken. This can be caused for a
- * number of reasons, for example:
+ * Exception raised when a communication channel is broken. This can be caused
+ * for a number of reasons, for example:
  *
  * <ul>
  * <li>an error in communication has occurred

--- a/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpErlangExternalFun.java
+++ b/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpErlangExternalFun.java
@@ -1,17 +1,19 @@
 /*
  * %CopyrightBegin%
  *
- * Copyright Ericsson AB 2009-2016. All Rights Reserved.
+ * Copyright Ericsson AB 2009-2021. All Rights Reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
- * file except in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under
- * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * %CopyrightEnd%
  */
@@ -21,12 +23,13 @@ public class OtpErlangExternalFun extends OtpErlangObject {
     // don't change this!
     private static final long serialVersionUID = 6443965570641913886L;
 
-    private final String module;
-    private final String function;
-    private final int arity;
+    public final String module;
+    public final String function;
+    public final int arity;
 
     public OtpErlangExternalFun(final String module, final String function,
             final int arity) {
+        super();
         this.module = module;
         this.function = function;
         this.arity = arity;
@@ -51,7 +54,8 @@ public class OtpErlangExternalFun extends OtpErlangObject {
             return false;
         }
         final OtpErlangExternalFun f = (OtpErlangExternalFun) o;
-        return module.equals(f.module) && function.equals(f.function) && arity == f.arity;
+        return module.equals(f.module) && function.equals(f.function)
+                && arity == f.arity;
     }
 
     @Override

--- a/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpErlangFloat.java
+++ b/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpErlangFloat.java
@@ -3,15 +3,17 @@
  *
  * Copyright Ericsson AB 2000-2016. All Rights Reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
- * file except in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under
- * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * %CopyrightEnd%
  */
@@ -32,15 +34,15 @@ public class OtpErlangFloat extends OtpErlangDouble {
     }
 
     /**
-     * Create an Erlang float from a stream containing a float encoded in Erlang external
-     * format.
+     * Create an Erlang float from a stream containing a float encoded in Erlang
+     * external format.
      *
      * @param buf
      *            the stream containing the encoded value.
      *
      * @exception OtpErlangDecodeException
-     *                if the buffer does not contain a valid external representation of an
-     *                Erlang float.
+     *                if the buffer does not contain a valid external
+     *                representation of an Erlang float.
      *
      * @exception OtpErlangRangeException
      *                if the value cannot be represented as a Java float.

--- a/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpErlangFun.java
+++ b/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpErlangFun.java
@@ -3,15 +3,17 @@
  *
  * Copyright Ericsson AB 2009-2016. All Rights Reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
- * file except in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under
- * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * %CopyrightEnd%
  */
@@ -32,7 +34,8 @@ public class OtpErlangFun extends OtpErlangObject {
     private final int arity;
     private final byte[] md5;
 
-    public OtpErlangFun(final OtpInputStream buf) throws OtpErlangDecodeException {
+    public OtpErlangFun(final OtpInputStream buf)
+            throws OtpErlangDecodeException {
         final OtpErlangFun f = buf.read_fun();
         pid = f.pid;
         module = f.module;
@@ -44,8 +47,8 @@ public class OtpErlangFun extends OtpErlangObject {
         freeVars = f.freeVars;
     }
 
-    public OtpErlangFun(final OtpErlangPid pid, final String module, final long index,
-            final long uniq, final OtpErlangObject[] freeVars) {
+    public OtpErlangFun(final OtpErlangPid pid, final String module,
+            final long index, final long uniq, final OtpErlangObject[] freeVars) {
         this.pid = pid;
         this.module = module;
         arity = -1;
@@ -56,8 +59,9 @@ public class OtpErlangFun extends OtpErlangObject {
         this.freeVars = freeVars;
     }
 
-    public OtpErlangFun(final OtpErlangPid pid, final String module, final int arity,
-            final byte[] md5, final int index, final long old_index, final long uniq,
+    public OtpErlangFun(final OtpErlangPid pid, final String module,
+            final int arity, final byte[] md5, final int index,
+            final long old_index, final long uniq,
             final OtpErlangObject[] freeVars) {
         this.pid = pid;
         this.module = module;
@@ -87,8 +91,10 @@ public class OtpErlangFun extends OtpErlangObject {
             if (f.md5 != null) {
                 return false;
             }
-        } else if (!Arrays.equals(md5, f.md5)) {
-            return false;
+        } else {
+            if (!Arrays.equals(md5, f.md5)) {
+                return false;
+            }
         }
         if (index != f.index || uniq != f.uniq) {
             return false;

--- a/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpErlangInt.java
+++ b/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpErlangInt.java
@@ -3,15 +3,17 @@
  *
  * Copyright Ericsson AB 2000-2016. All Rights Reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
- * file except in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under
- * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * %CopyrightEnd%
  */
@@ -35,15 +37,15 @@ public class OtpErlangInt extends OtpErlangLong {
     }
 
     /**
-     * Create an Erlang integer from a stream containing an integer encoded in Erlang
-     * external format.
+     * Create an Erlang integer from a stream containing an integer encoded in
+     * Erlang external format.
      *
      * @param buf
      *            the stream containing the encoded value.
      *
      * @exception OtpErlangDecodeException
-     *                if the buffer does not contain a valid external representation of an
-     *                Erlang integer.
+     *                if the buffer does not contain a valid external
+     *                representation of an Erlang integer.
      *
      * @exception OtpErlangRangeException
      *                if the value is too large to be represented as an int.

--- a/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpErlangList.java
+++ b/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpErlangList.java
@@ -3,15 +3,17 @@
  *
  * Copyright Ericsson AB 2000-2016. All Rights Reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
- * file except in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under
- * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * %CopyrightEnd%
  */
@@ -21,13 +23,14 @@ import java.util.Iterator;
 import java.util.NoSuchElementException;
 
 /**
- * Provides a Java representation of Erlang lists. Lists are created from zero or more
- * arbitrary Erlang terms.
+ * Provides a Java representation of Erlang lists. Lists are created from zero
+ * or more arbitrary Erlang terms.
  *
  * <p>
  * The arity of the list is the number of elements it contains.
  */
-public class OtpErlangList extends OtpErlangObject implements Iterable<OtpErlangObject> {
+public class OtpErlangList extends OtpErlangObject implements
+        Iterable<OtpErlangObject> {
     // don't change this!
     private static final long serialVersionUID = 5999112769036676548L;
 
@@ -45,8 +48,8 @@ public class OtpErlangList extends OtpErlangObject implements Iterable<OtpErlang
     }
 
     /**
-     * Create a list of Erlang integers representing Unicode codePoints. This method does
-     * not check if the string contains valid code points.
+     * Create a list of Erlang integers representing Unicode codePoints. This
+     * method does not check if the string contains valid code points.
      *
      * @param str
      *            the characters from which to create the list.
@@ -84,16 +87,16 @@ public class OtpErlangList extends OtpErlangObject implements Iterable<OtpErlang
     }
 
     /**
-     * Create a list from an array of arbitrary Erlang terms. Tail can be specified, if
-     * not null, the list will not be proper.
+     * Create a list from an array of arbitrary Erlang terms. Tail can be
+     * specified, if not null, the list will not be proper.
      *
      * @param elems
      *            array of terms from which to create the list
      * @param lastTail
      * @throws OtpErlangException
      */
-    public OtpErlangList(final OtpErlangObject[] elems, final OtpErlangObject lastTail)
-            throws OtpErlangException {
+    public OtpErlangList(final OtpErlangObject[] elems,
+            final OtpErlangObject lastTail) throws OtpErlangException {
         this(elems, 0, elems.length);
         if (elems.length == 0 && lastTail != null) {
             throw new OtpErlangException("Bad list, empty head, non-empty tail");
@@ -122,16 +125,18 @@ public class OtpErlangList extends OtpErlangObject implements Iterable<OtpErlang
     }
 
     /**
-     * Create a list from a stream containing an list encoded in Erlang external format.
+     * Create a list from a stream containing an list encoded in Erlang external
+     * format.
      *
      * @param buf
      *            the stream containing the encoded list.
      *
      * @exception OtpErlangDecodeException
-     *                if the buffer does not contain a valid external representation of an
-     *                Erlang list.
+     *                if the buffer does not contain a valid external
+     *                representation of an Erlang list.
      */
-    public OtpErlangList(final OtpInputStream buf) throws OtpErlangDecodeException {
+    public OtpErlangList(final OtpInputStream buf)
+            throws OtpErlangDecodeException {
         final int arity = buf.read_list_head();
         if (arity > 0) {
             elems = new OtpErlangObject[arity];
@@ -162,8 +167,8 @@ public class OtpErlangList extends OtpErlangObject implements Iterable<OtpErlang
      * Get the specified element from the list.
      *
      * @param i
-     *            the index of the requested element. List elements are numbered as array
-     *            elements, starting at 0.
+     *            the index of the requested element. List elements are numbered
+     *            as array elements, starting at 0.
      *
      * @return the requested element, of null if i is not a valid element index.
      */
@@ -218,8 +223,9 @@ public class OtpErlangList extends OtpErlangObject implements Iterable<OtpErlang
     }
 
     /**
-     * Convert this list to the equivalent Erlang external representation. Note that this
-     * method never encodes lists as strings, even when it is possible to do so.
+     * Convert this list to the equivalent Erlang external representation. Note
+     * that this method never encodes lists as strings, even when it is possible
+     * to do so.
      *
      * @param buf
      *            An output stream to which the encoded list should be written.
@@ -249,21 +255,22 @@ public class OtpErlangList extends OtpErlangObject implements Iterable<OtpErlang
     }
 
     /**
-     * Determine if two lists are equal. Lists are equal if they have the same arity and
-     * all of the elements are equal.
+     * Determine if two lists are equal. Lists are equal if they have the same
+     * arity and all of the elements are equal.
      *
      * @param o
      *            the list to compare to.
      *
-     * @return true if the lists have the same arity and all the elements are equal.
+     * @return true if the lists have the same arity and all the elements are
+     *         equal.
      */
 
     @Override
     public boolean equals(final Object o) {
 
         /*
-         * Be careful to use methods even for "this", so that equals work also for
-         * sublists
+         * Be careful to use methods even for "this", so that equals work also
+         * for sublists
          */
 
         if (!(o instanceof OtpErlangList)) {
@@ -298,17 +305,19 @@ public class OtpErlangList extends OtpErlangObject implements Iterable<OtpErlang
         }
         final OtpErlangList that = (OtpErlangList) term;
 
-        final int thisArity = arity();
+        final int thisArity = this.arity();
         final int thatArity = that.arity();
-        final OtpErlangObject thisTail = getLastTail();
+        final OtpErlangObject thisTail = this.getLastTail();
         final OtpErlangObject thatTail = that.getLastTail();
 
         if (thisTail == null) {
             if (thisArity != thatArity || thatTail != null) {
                 return false;
             }
-        } else if (thisArity > thatArity) {
-            return false;
+        } else {
+            if (thisArity > thatArity) {
+                return false;
+            }
         }
         for (int i = 0; i < thisArity; i++) {
             if (!elementAt(i).match(that.elementAt(i), bindings)) {
@@ -323,7 +332,7 @@ public class OtpErlangList extends OtpErlangObject implements Iterable<OtpErlang
 
     @Override
     public <T> OtpErlangObject bind(final T binds) throws OtpErlangException {
-        final OtpErlangList list = (OtpErlangList) clone();
+        final OtpErlangList list = (OtpErlangList) this.clone();
 
         final int a = list.elems.length;
         for (int i = 0; i < a; i++) {
@@ -368,7 +377,6 @@ public class OtpErlangList extends OtpErlangObject implements Iterable<OtpErlang
         }
     }
 
-    @Override
     public Iterator<OtpErlangObject> iterator() {
         return iterator(0);
     }
@@ -407,11 +415,11 @@ public class OtpErlangList extends OtpErlangObject implements Iterable<OtpErlang
     }
 
     /**
-     * Convert a list of integers into a Unicode string, interpreting each integer as a
-     * Unicode code point value.
+     * Convert a list of integers into a Unicode string, interpreting each
+     * integer as a Unicode code point value.
      *
-     * @return A java.lang.String object created through its constructor String(int[],
-     *         int, int).
+     * @return A java.lang.String object created through its constructor
+     *         String(int[], int, int).
      *
      * @exception OtpErlangException
      *                for non-proper and non-integer lists.
@@ -450,6 +458,7 @@ public class OtpErlangList extends OtpErlangObject implements Iterable<OtpErlang
         private final OtpErlangList parent;
 
         private SubList(final OtpErlangList parent, final int start) {
+            super();
             this.parent = parent;
             this.start = start;
         }
@@ -520,12 +529,10 @@ public class OtpErlangList extends OtpErlangObject implements Iterable<OtpErlang
             this.cursor = cursor;
         }
 
-        @Override
         public boolean hasNext() {
             return cursor < elems.length;
         }
 
-        @Override
         public OtpErlangObject next() {
             try {
                 return elems[cursor++];
@@ -534,9 +541,9 @@ public class OtpErlangList extends OtpErlangObject implements Iterable<OtpErlang
             }
         }
 
-        @Override
         public void remove() {
-            throw new UnsupportedOperationException("OtpErlangList cannot be modified!");
+            throw new UnsupportedOperationException(
+                    "OtpErlangList cannot be modified!");
         }
     }
 }

--- a/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpErlangLong.java
+++ b/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpErlangLong.java
@@ -1,17 +1,19 @@
 /*
  * %CopyrightBegin%
  *
- * Copyright Ericsson AB 2000-2016. All Rights Reserved.
+ * Copyright Ericsson AB 2000-2022. All Rights Reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
- * file except in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under
- * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * %CopyrightEnd%
  */
@@ -20,12 +22,13 @@ package com.ericsson.otp.erlang;
 import java.math.BigInteger;
 
 /**
- * Provides a Java representation of Erlang integral types. Erlang does not distinguish
- * between different integral types, however this class and its subclasses
- * {@link OtpErlangByte}, {@link OtpErlangChar}, {@link OtpErlangInt} , and
- * {@link OtpErlangShort} attempt to map the Erlang types onto the various Java integral
- * types. Two additional classes, {@link OtpErlangUInt} and {@link OtpErlangUShort} are
- * provided for Corba compatibility. See the documentation for IC for more information.
+ * Provides a Java representation of Erlang integral types. Erlang does not
+ * distinguish between different integral types, however this class and its
+ * subclasses {@link OtpErlangByte}, {@link OtpErlangChar}, {@link OtpErlangInt}
+ * , and {@link OtpErlangShort} attempt to map the Erlang types onto the various
+ * Java integral types. Two additional classes, {@link OtpErlangUInt} and
+ * {@link OtpErlangUShort} are provided for Corba compatibility. See the
+ * documentation for IC for more information.
  */
 public class OtpErlangLong extends OtpErlangObject {
     // don't change this!
@@ -62,17 +65,18 @@ public class OtpErlangLong extends OtpErlangObject {
     }
 
     /**
-     * Create an Erlang integer from a stream containing an integer encoded in Erlang
-     * external format.
+     * Create an Erlang integer from a stream containing an integer encoded in
+     * Erlang external format.
      *
      * @param buf
      *            the stream containing the encoded value.
      *
      * @exception OtpErlangDecodeException
-     *                if the buffer does not contain a valid external representation of an
-     *                Erlang integer.
+     *                if the buffer does not contain a valid external
+     *                representation of an Erlang integer.
      */
-    public OtpErlangLong(final OtpInputStream buf) throws OtpErlangDecodeException {
+    public OtpErlangLong(final OtpInputStream buf)
+            throws OtpErlangDecodeException {
         final byte[] b = buf.read_integer_byte_array();
         try {
             val = OtpInputStream.byte_array_to_long(b, false);
@@ -94,8 +98,9 @@ public class OtpErlangLong extends OtpErlangObject {
     }
 
     /**
-     * Get this number as a long, or rather truncate all but the least significant 64 bits
-     * from the 2's complement representation of this number and return them as a long.
+     * Get this number as a long, or rather truncate all but the least
+     * significant 64 bits from the 2's complement representation of this number
+     * and return them as a long.
      *
      * @return the value of this number, as a long.
      */
@@ -112,7 +117,7 @@ public class OtpErlangLong extends OtpErlangObject {
      * @return true if this value fits in a long, false otherwise.
      */
     public boolean isLong() {
-        // To just chech this.bigVal is a wee bit to simple, since
+        // To just check this.bigVal is a wee bit to simple, since
         // there just might have be a mean bignum that arrived on
         // a stream, and was a long disguised as more than 8 byte integer.
         if (bigVal != null) {
@@ -122,10 +127,12 @@ public class OtpErlangLong extends OtpErlangObject {
     }
 
     /**
-     * Determine if this value can be represented as an unsigned long without truncation,
-     * that is if the value is non-negative and its bit pattern completely fits in a long.
+     * Determine if this value can be represented as an unsigned long without
+     * truncation, that is if the value is non-negative and its bit pattern
+     * completely fits in a long.
      *
-     * @return true if this value is non-negative and fits in a long false otherwise.
+     * @return true if this value is non-negative and fits in a long false
+     *         otherwise.
      */
     public boolean isULong() {
         // Here we have the same problem as for isLong(), plus
@@ -137,11 +144,11 @@ public class OtpErlangLong extends OtpErlangObject {
     }
 
     /**
-     * Returns the number of bits in the minimal two's-complement representation of this
-     * BigInteger, excluding a sign bit.
+     * Returns the number of bits in the minimal two's-complement representation
+     * of this BigInteger, excluding a sign bit.
      *
-     * @return number of bits in the minimal two's-complement representation of this
-     *         BigInteger, excluding a sign bit.
+     * @return number of bits in the minimal two's-complement representation of
+     *         this BigInteger, excluding a sign bit.
      */
     public int bitLength() {
         if (bigVal != null) {
@@ -221,8 +228,8 @@ public class OtpErlangLong extends OtpErlangObject {
      * @return the value of this number, as an int.
      *
      * @exception OtpErlangRangeException
-     *                if the value is too large to be represented as an int, or if the
-     *                value is negative.
+     *                if the value is too large to be represented as an int, or
+     *                if the value is negative.
      */
     public int uIntValue() throws OtpErlangRangeException {
         final long l = longValue();
@@ -250,7 +257,8 @@ public class OtpErlangLong extends OtpErlangObject {
         final short i = (short) l;
 
         if (i != l) {
-            throw new OtpErlangRangeException("Value too large for short: " + val);
+            throw new OtpErlangRangeException("Value too large for short: "
+                    + val);
         }
 
         return i;
@@ -262,15 +270,16 @@ public class OtpErlangLong extends OtpErlangObject {
      * @return the value of this number, as a short.
      *
      * @exception OtpErlangRangeException
-     *                if the value is too large to be represented as a short, or if the
-     *                value is negative.
+     *                if the value is too large to be represented as a short, or
+     *                if the value is negative.
      */
     public short uShortValue() throws OtpErlangRangeException {
         final long l = longValue();
         final short i = (short) l;
 
         if (i != l) {
-            throw new OtpErlangRangeException("Value too large for short: " + val);
+            throw new OtpErlangRangeException("Value too large for short: "
+                    + val);
         } else if (i < 0) {
             throw new OtpErlangRangeException("Value not positive: " + val);
         }
@@ -291,7 +300,8 @@ public class OtpErlangLong extends OtpErlangObject {
         final char i = (char) l;
 
         if (i != l) {
-            throw new OtpErlangRangeException("Value too large for char: " + val);
+            throw new OtpErlangRangeException("Value too large for char: "
+                    + val);
         }
 
         return i;
@@ -310,7 +320,8 @@ public class OtpErlangLong extends OtpErlangObject {
         final byte i = (byte) l;
 
         if (i != l) {
-            throw new OtpErlangRangeException("Value too large for byte: " + val);
+            throw new OtpErlangRangeException("Value too large for byte: "
+                    + val);
         }
 
         return i;
@@ -333,7 +344,8 @@ public class OtpErlangLong extends OtpErlangObject {
      * Convert this number to the equivalent Erlang external representation.
      *
      * @param buf
-     *            an output stream to which the encoded number should be written.
+     *            an output stream to which the encoded number should be
+     *            written.
      */
     @Override
     public void encode(final OtpOutputStream buf) {
@@ -345,8 +357,8 @@ public class OtpErlangLong extends OtpErlangObject {
     }
 
     /**
-     * Determine if two numbers are equal. Numbers are equal if they contain the same
-     * value.
+     * Determine if two numbers are equal. Numbers are equal if they contain the
+     * same value.
      *
      * @param o
      *            the number to compare to.

--- a/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpErlangMap.java
+++ b/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpErlangMap.java
@@ -3,15 +3,17 @@
  *
  * Copyright Ericsson AB 2000-2016. All Rights Reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
- * file except in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under
- * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * %CopyrightEnd%
  */
@@ -23,12 +25,12 @@ import java.util.Map.Entry;
 import java.util.Set;
 
 /**
- * Provides a Java representation of Erlang maps. Maps are created from one or more
- * arbitrary Erlang terms.
+ * Provides a Java representation of Erlang maps. Maps are created from one or
+ * more arbitrary Erlang terms.
  *
  * <p>
- * The arity of the map is the number of elements it contains. The keys and values can be
- * retrieved as arrays and the value for a key can be queried.
+ * The arity of the map is the number of elements it contains. The keys and
+ * values can be retrieved as arrays and the value for a key can be queried.
  *
  */
 public class OtpErlangMap extends OtpErlangObject {
@@ -37,10 +39,12 @@ public class OtpErlangMap extends OtpErlangObject {
 
     private OtpMap map;
 
-    private static class OtpMap extends LinkedHashMap<OtpErlangObject, OtpErlangObject> {
+    private static class OtpMap
+            extends LinkedHashMap<OtpErlangObject, OtpErlangObject> {
         private static final long serialVersionUID = -2666505810905455082L;
 
         public OtpMap() {
+            super();
         }
     }
 
@@ -62,7 +66,8 @@ public class OtpErlangMap extends OtpErlangObject {
      * @exception java.lang.IllegalArgumentException
      *                if any array is empty (null) or contains null elements.
      */
-    public OtpErlangMap(final OtpErlangObject[] keys, final OtpErlangObject[] values) {
+    public OtpErlangMap(final OtpErlangObject[] keys,
+            final OtpErlangObject[] values) {
         this(keys, 0, keys.length, values, 0, values.length);
     }
 
@@ -87,10 +92,12 @@ public class OtpErlangMap extends OtpErlangObject {
      * @exception java.lang.IllegalArgumentException
      *                if kcount and vcount differ.
      */
-    public OtpErlangMap(final OtpErlangObject[] keys, final int kstart, final int kcount,
-            final OtpErlangObject[] values, final int vstart, final int vcount) {
+    public OtpErlangMap(final OtpErlangObject[] keys, final int kstart,
+            final int kcount, final OtpErlangObject[] values, final int vstart,
+            final int vcount) {
         if (keys == null || values == null) {
-            throw new java.lang.IllegalArgumentException("Map content can't be null");
+            throw new java.lang.IllegalArgumentException(
+                    "Map content can't be null");
         } else if (kcount != vcount) {
             throw new java.lang.IllegalArgumentException(
                     "Map keys and values must have same arity");
@@ -104,23 +111,26 @@ public class OtpErlangMap extends OtpErlangObject {
             }
             if ((val = values[vstart + i]) == null) {
                 throw new java.lang.IllegalArgumentException(
-                        "Map value cannot be null (element" + (vstart + i) + ")");
+                        "Map value cannot be null (element" + (vstart + i)
+                                + ")");
             }
             put(key, val);
         }
     }
 
     /**
-     * Create a map from a stream containing a map encoded in Erlang external format.
+     * Create a map from a stream containing a map encoded in Erlang external
+     * format.
      *
      * @param buf
      *            the stream containing the encoded map.
      *
      * @exception OtpErlangDecodeException
-     *                if the buffer does not contain a valid external representation of an
-     *                Erlang map.
+     *                if the buffer does not contain a valid external
+     *                representation of an Erlang map.
      */
-    public OtpErlangMap(final OtpInputStream buf) throws OtpErlangDecodeException {
+    public OtpErlangMap(final OtpInputStream buf)
+            throws OtpErlangDecodeException {
         final int arity = buf.read_map_head();
 
         if (arity > 0) {
@@ -146,8 +156,8 @@ public class OtpErlangMap extends OtpErlangObject {
     }
 
     /**
-     * Put value corresponding to key into the map. For detailed behavior description see
-     * {@link Map#put(Object, Object)}.
+     * Put value corresponding to key into the map. For detailed behavior
+     * description see {@link Map#put(Object, Object)}.
      *
      * @param key
      *            key to associate value with
@@ -155,7 +165,8 @@ public class OtpErlangMap extends OtpErlangObject {
      *            value to associate with key
      * @return previous value associated with key or null
      */
-    public OtpErlangObject put(final OtpErlangObject key, final OtpErlangObject value) {
+    public OtpErlangObject put(final OtpErlangObject key,
+            final OtpErlangObject value) {
         return map.put(key, value);
     }
 
@@ -256,13 +267,14 @@ public class OtpErlangMap extends OtpErlangObject {
     }
 
     /**
-     * Determine if two maps are equal. Maps are equal if they have the same arity and all
-     * of the elements are equal.
+     * Determine if two maps are equal. Maps are equal if they have the same
+     * arity and all of the elements are equal.
      *
      * @param o
      *            the map to compare to.
      *
-     * @return true if the maps have the same arity and all the elements are equal.
+     * @return true if the maps have the same arity and all the elements are
+     *         equal.
      */
     @Override
     public boolean equals(final Object o) {

--- a/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpErlangObject.java
+++ b/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpErlangObject.java
@@ -3,15 +3,17 @@
  *
  * Copyright Ericsson AB 2000-2016. All Rights Reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
- * file except in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under
- * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * %CopyrightEnd%
  */
@@ -20,8 +22,8 @@ package com.ericsson.otp.erlang;
 import java.io.Serializable;
 
 /**
- * Base class of the Erlang data type classes. This class is used to represent an
- * arbitrary Erlang term.
+ * Base class of the Erlang data type classes. This class is used to represent
+ * an arbitrary Erlang term.
  */
 public abstract class OtpErlangObject implements Serializable, Cloneable {
     protected int hashCodeValue = 0;
@@ -30,16 +32,17 @@ public abstract class OtpErlangObject implements Serializable, Cloneable {
     static final long serialVersionUID = -8435938572339430044L;
 
     /**
-     * @return the printable representation of the object. This is usually similar to the
-     *         representation used by Erlang for the same type of object.
+     * @return the printable representation of the object. This is usually
+     *         similar to the representation used by Erlang for the same type of
+     *         object.
      */
     @Override
     public abstract String toString();
 
     /**
-     * Convert the object according to the rules of the Erlang external format. This is
-     * mainly used for sending Erlang terms in messages, however it can also be used for
-     * storing terms to disk.
+     * Convert the object according to the rules of the Erlang external format.
+     * This is mainly used for sending Erlang terms in messages, however it can
+     * also be used for storing terms to disk.
      *
      * @param buf
      *            an output stream to which the encoded term should be written.
@@ -47,9 +50,10 @@ public abstract class OtpErlangObject implements Serializable, Cloneable {
     public abstract void encode(OtpOutputStream buf);
 
     /**
-     * Read binary data in the Erlang external format, and produce a corresponding Erlang
-     * data type object. This method is normally used when Erlang terms are received in
-     * messages, however it can also be used for reading terms from disk.
+     * Read binary data in the Erlang external format, and produce a
+     * corresponding Erlang data type object. This method is normally used when
+     * Erlang terms are received in messages, however it can also be used for
+     * reading terms from disk.
      *
      * @param buf
      *            an input stream containing one or more encoded Erlang terms.
@@ -57,8 +61,8 @@ public abstract class OtpErlangObject implements Serializable, Cloneable {
      * @return an object representing one of the Erlang data types.
      *
      * @exception OtpErlangDecodeException
-     *                if the stream does not contain a valid representation of an Erlang
-     *                term.
+     *                if the stream does not contain a valid representation of
+     *                an Erlang term.
      */
     public static OtpErlangObject decode(final OtpInputStream buf)
             throws OtpErlangDecodeException {
@@ -66,8 +70,8 @@ public abstract class OtpErlangObject implements Serializable, Cloneable {
     }
 
     /**
-     * Determine if two Erlang objects are equal. In general, Erlang objects are equal if
-     * the components they consist of are equal.
+     * Determine if two Erlang objects are equal. In general, Erlang objects are
+     * equal if the components they consist of are equal.
      *
      * @param o
      *            the object to compare to.
@@ -91,8 +95,8 @@ public abstract class OtpErlangObject implements Serializable, Cloneable {
     }
 
     /**
-     * Make new Erlang term replacing variables with the respective values from bindings
-     * argument(s).
+     * Make new Erlang term replacing variables with the respective values from
+     * bindings argument(s).
      *
      * @param binds
      *            variable bindings
@@ -129,8 +133,8 @@ public abstract class OtpErlangObject implements Serializable, Cloneable {
         int abc[] = { 0, 0, 0 };
 
         /*
-         * Hash function suggested by Bob Jenkins. The same as in the Erlang VM (beam);
-         * utils.c.
+         * Hash function suggested by Bob Jenkins. The same as in the Erlang VM
+         * (beam); utils.c.
          */
 
         private final static int HASH_CONST[] = { 0, // not used

--- a/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpErlangPid.java
+++ b/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpErlangPid.java
@@ -1,25 +1,27 @@
 /*
  * %CopyrightBegin%
  *
- * Copyright Ericsson AB 2000-2016. All Rights Reserved.
+ * Copyright Ericsson AB 2000-2021. All Rights Reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
- * file except in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under
- * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * %CopyrightEnd%
  */
 package com.ericsson.otp.erlang;
 
 /**
- * Provides a Java representation of Erlang PIDs. PIDs represent Erlang processes and
- * consist of a nodename and a number of integers.
+ * Provides a Java representation of Erlang PIDs. PIDs represent Erlang
+ * processes and consist of a nodename and a number of integers.
  */
 public class OtpErlangPid extends OtpErlangObject implements Comparable<Object> {
     // don't change this!
@@ -49,17 +51,18 @@ public class OtpErlangPid extends OtpErlangObject implements Comparable<Object> 
     }
 
     /**
-     * Create an Erlang PID from a stream containing a PID encoded in Erlang external
-     * format.
+     * Create an Erlang PID from a stream containing a PID encoded in Erlang
+     * external format.
      *
      * @param buf
      *            the stream containing the encoded PID.
      *
      * @exception OtpErlangDecodeException
-     *                if the buffer does not contain a valid external representation of an
-     *                Erlang PID.
+     *                if the buffer does not contain a valid external
+     *                representation of an Erlang PID.
      */
-    public OtpErlangPid(final OtpInputStream buf) throws OtpErlangDecodeException {
+    public OtpErlangPid(final OtpInputStream buf)
+            throws OtpErlangDecodeException {
         final OtpErlangPid p = buf.read_pid();
 
         node = p.node();
@@ -78,24 +81,25 @@ public class OtpErlangPid extends OtpErlangObject implements Comparable<Object> 
      *            an arbitrary number. Only the low order 15 bits will be used.
      *
      * @param serial
-     *            another arbitrary number. Only the low order 13 bits will be used.
+     *            another arbitrary number. Only the low order 13 bits will be
+     *            used.
      *
      * @param creation
-     *            yet another arbitrary number. Ony the low order 2 bits will be used.
+	 *  		  node incarnation number. Avoid values 0 to 3.
      */
     public OtpErlangPid(final String node, final int id, final int serial,
-            final int creation) {
-        this(OtpExternal.pidTag, node, id, serial, creation);
+			final int creation) {
+		this(OtpExternal.newPidTag, node, id, serial, creation);
     }
 
     /**
      * Create an Erlang pid from its components.
      *
      * @param tag
-     *            the external format to be compliant with OtpExternal.pidTag where only a
-     *            subset of the bits are significant (see other constructor).
-     *            OtpExternal.newPidTag where all 32 bits of id,serial and creation are
-     *            significant. newPidTag can only be decoded by OTP-19 and newer.
+     *            the external format to be compliant with
+     *            OtpExternal.pidTag where only a subset of the bits are significant (see other constructor).
+     *            OtpExternal.newPidTag where all 32 bits of id,serial and creation are significant.
+     *            newPidTag can only be decoded by OTP-19 and newer.
      * @param node
      *            the nodename.
      *
@@ -109,21 +113,22 @@ public class OtpErlangPid extends OtpErlangObject implements Comparable<Object> 
      *            yet another arbitrary number.
      */
     protected OtpErlangPid(final int tag, final String node, final int id,
-            final int serial, final int creation) {
-        this.node = node;
-        if (tag == OtpExternal.pidTag) {
-            this.id = id & 0x7fff; // 15 bits
-            this.serial = serial & 0x1fff; // 13 bits
-            this.creation = creation & 0x03; // 2 bits
-        } else { // allow all 32 bits for newPidTag
-            this.id = id;
-            this.serial = serial;
-            this.creation = creation;
-        }
+			   final int serial, final int creation) {
+	this.node = node;
+	if (tag == OtpExternal.pidTag) {
+	    this.id = id & 0x7fff; // 15 bits
+	    this.serial = serial & 0x1fff; // 13 bits
+	    this.creation = creation & 0x03; // 2 bits
+	}
+	else {  // allow all 32 bits for newPidTag
+	    this.id = id;
+	    this.serial = serial;
+	    this.creation = creation;
+	}
     }
 
     protected int tag() {
-        return OtpExternal.newPidTag;
+	return OtpExternal.newPidTag;
     }
 
     /**
@@ -185,7 +190,8 @@ public class OtpErlangPid extends OtpErlangObject implements Comparable<Object> 
     }
 
     /**
-     * Determine if two PIDs are equal. PIDs are equal if their components are equal.
+     * Determine if two PIDs are equal. PIDs are equal if their components are
+     * equal.
      *
      * @param o
      *            the other PID to compare to.
@@ -212,7 +218,6 @@ public class OtpErlangPid extends OtpErlangObject implements Comparable<Object> 
         return hash.valueOf();
     }
 
-    @Override
     public int compareTo(final Object o) {
         if (!(o instanceof OtpErlangPid)) {
             return -1;

--- a/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpErlangPort.java
+++ b/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpErlangPort.java
@@ -1,17 +1,19 @@
 /*
  * %CopyrightBegin%
  *
- * Copyright Ericsson AB 2000-2016. All Rights Reserved.
+ * Copyright Ericsson AB 2000-2021. All Rights Reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
- * file except in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under
- * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * %CopyrightEnd%
  */
@@ -29,8 +31,8 @@ public class OtpErlangPort extends OtpErlangObject {
     private final int creation;
 
     /*
-     * Create a unique Erlang port belonging to the local node. Since it isn't meaninful
-     * to do so, this constructor is private...
+     * Create a unique Erlang port belonging to the local node. Since it isn't
+     * meaningful to do so, this constructor is private...
      *
      * @param self the local node.
      *
@@ -46,17 +48,18 @@ public class OtpErlangPort extends OtpErlangObject {
     }
 
     /**
-     * Create an Erlang port from a stream containing a port encoded in Erlang external
-     * format.
+     * Create an Erlang port from a stream containing a port encoded in Erlang
+     * external format.
      *
      * @param buf
      *            the stream containing the encoded port.
      *
      * @exception OtpErlangDecodeException
-     *                if the buffer does not contain a valid external representation of an
-     *                Erlang port.
+     *                if the buffer does not contain a valid external
+     *                representation of an Erlang port.
      */
-    public OtpErlangPort(final OtpInputStream buf) throws OtpErlangDecodeException {
+    public OtpErlangPort(final OtpInputStream buf)
+            throws OtpErlangDecodeException {
         final OtpErlangPort p = buf.read_port();
 
         node = p.node();
@@ -74,20 +77,20 @@ public class OtpErlangPort extends OtpErlangObject {
      *            an arbitrary number. Only the low order 28 bits will be used.
      *
      * @param creation
-     *            another arbitrary number. Only the low order 2 bits will be used.
+	 *  		  node incarnation number. Avoid values 0 to 3.
      */
     public OtpErlangPort(final String node, final long id, final int creation) {
-        this(OtpExternal.portTag, node, id, creation);
+		this(OtpExternal.newPortTag, node, id, creation);
     }
 
     /**
      * Create an Erlang port from its components.
      *
      * @param tag
-     *            the external format to be compliant with. OtpExternal.portTag where only
-     *            a subset of the bits are used (see other constructor)
-     *            OtpExternal.newPortTag where all 32 bits of id and creation are
-     *            significant. newPortTag can only be decoded by OTP-19 and newer.
+     *            the external format to be compliant with.
+     *            OtpExternal.portTag where only a subset of the bits are used (see other constructor)
+     *            OtpExternal.newPortTag where all 32 bits of id and creation are significant.
+     *            newPortTag can only be decoded by OTP-19 and newer.
      * @param node
      *            the nodename.
      *
@@ -98,15 +101,16 @@ public class OtpErlangPort extends OtpErlangObject {
      *            another arbitrary number.
      */
     public OtpErlangPort(final int tag, final String node, final long id,
-            final int creation) {
-        this.node = node;
-        if (tag == OtpExternal.portTag) {
-            this.id = id & 0xfffffff; // 28 bits
-            this.creation = creation & 0x3; // 2 bits
-        } else {
-            this.id = id;
-            this.creation = creation;
-        }
+			 final int creation) {
+	this.node = node;
+	if (tag == OtpExternal.portTag) {
+	    this.id = id & 0xfffffff; // 28 bits
+	    this.creation = creation & 0x3; // 2 bits
+	}
+	else {
+	    this.id = id;
+	    this.creation = creation;
+	}
     }
 
     protected int tag() {
@@ -163,7 +167,8 @@ public class OtpErlangPort extends OtpErlangObject {
     }
 
     /**
-     * Determine if two ports are equal. Ports are equal if their components are equal.
+     * Determine if two ports are equal. Ports are equal if their components are
+     * equal.
      *
      * @param o
      *            the other port to compare to.

--- a/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpErlangRangeException.java
+++ b/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpErlangRangeException.java
@@ -3,23 +3,25 @@
  *
  * Copyright Ericsson AB 2000-2016. All Rights Reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
- * file except in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under
- * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * %CopyrightEnd%
  */
 package com.ericsson.otp.erlang;
 
 /**
- * Exception raised when an attempt is made to create an Erlang term with data that is out
- * of range for the term in question.
+ * Exception raised when an attempt is made to create an Erlang term with data
+ * that is out of range for the term in question.
  *
  * @see OtpErlangByte
  * @see OtpErlangChar

--- a/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpErlangRef.java
+++ b/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpErlangRef.java
@@ -1,25 +1,28 @@
 /*
  * %CopyrightBegin%
  *
- * Copyright Ericsson AB 2000-2016. All Rights Reserved.
+ * Copyright Ericsson AB 2000-2021. All Rights Reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
- * file except in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under
- * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * %CopyrightEnd%
  */
 package com.ericsson.otp.erlang;
 
 /**
- * Provides a Java representation of Erlang refs. There are two styles of Erlang refs, old
- * style (one id value) and new style (array of id values). This class manages both types.
+ * Provides a Java representation of Erlang refs. There are two styles of Erlang
+ * refs, old style (one id value) and new style (array of id values). This class
+ * manages both types.
  */
 public class OtpErlangRef extends OtpErlangObject {
     // don't change this!
@@ -51,17 +54,18 @@ public class OtpErlangRef extends OtpErlangObject {
     }
 
     /**
-     * Create an Erlang ref from a stream containing a ref encoded in Erlang external
-     * format.
+     * Create an Erlang ref from a stream containing a ref encoded in Erlang
+     * external format.
      *
      * @param buf
      *            the stream containing the encoded ref.
      *
      * @exception OtpErlangDecodeException
-     *                if the buffer does not contain a valid external representation of an
-     *                Erlang ref.
+     *                if the buffer does not contain a valid external
+     *                representation of an Erlang ref.
      */
-    public OtpErlangRef(final OtpInputStream buf) throws OtpErlangDecodeException {
+    public OtpErlangRef(final OtpInputStream buf)
+            throws OtpErlangDecodeException {
         final OtpErlangRef r = buf.read_ref();
 
         node = r.node();
@@ -96,24 +100,24 @@ public class OtpErlangRef extends OtpErlangObject {
      *            the nodename.
      *
      * @param ids
-     *            an array of arbitrary numbers. Only the low order 18 bits of the first
-     *            number will be used. If the array contains only one number, an old style
-     *            ref will be written instead. At most three numbers will be read from the
-     *            array.
+     *            an array of arbitrary numbers. Only the low order 18 bits of
+     *            the first number will be used. If the array contains only one
+     *            number, an old style ref will be written instead. At most
+     *            three numbers will be read from the array.
      *
      * @param creation
-     *            another arbitrary number. Only the low order 2 bits will be used.
+	 *  		  node incarnation number. Avoid values 0 to 3.
      */
     public OtpErlangRef(final String node, final int[] ids, final int creation) {
-        this(OtpExternal.newRefTag, node, ids, creation);
-    }
+		this(OtpExternal.newerRefTag, node, ids, creation);
+	}
 
     /**
      * Create a new(er) style Erlang ref from its components.
      *
      * @param tag
-     *            the external format to be compliant with. OtpExternal.newRefTag where
-     *            only a subset of the bits are used (see other constructor)
+     *            the external format to be compliant with.
+     *            OtpExternal.newRefTag where only a subset of the bits are used (see other constructor)
      *            OtpExternal.newerRefTag where all bits of ids and creation are used.
      *            newerPortTag can only be decoded by OTP-19 and newer.
      *
@@ -121,14 +125,14 @@ public class OtpErlangRef extends OtpErlangObject {
      *            the nodename.
      *
      * @param ids
-     *            an array of arbitrary numbers. At most three numbers will be read from
-     *            the array.
+     *            an array of arbitrary numbers. At most three numbers
+     *            will be read from the array.
      *
      * @param creation
      *            another arbitrary number.
      */
     public OtpErlangRef(final int tag, final String node, final int[] ids,
-            final int creation) {
+			final int creation) {
         this.node = node;
 
         // use at most 5 words
@@ -138,19 +142,22 @@ public class OtpErlangRef extends OtpErlangObject {
             this.ids[0] = 0;
             this.ids[1] = 0;
             this.ids[2] = 0;
-        } else if (len <= 5) {
+        }
+        else if (len <= 5) {
             this.ids = new int[len];
-        } else {
+        }
+        else {
             this.ids = new int[5];
             len = 5;
         }
         System.arraycopy(ids, 0, this.ids, 0, len);
-        if (tag == OtpExternal.newRefTag) {
-            this.creation = creation & 0x3;
-            this.ids[0] &= 0x3ffff; // only 18 significant bits in first number
-        } else {
-            this.creation = creation;
-        }
+	if (tag == OtpExternal.newRefTag) {
+	    this.creation = creation & 0x3;
+	    this.ids[0] &= 0x3ffff; // only 18 significant bits in first number
+	}
+	else {
+	    this.creation = creation;
+	}
     }
 
     protected int tag() {
@@ -158,8 +165,8 @@ public class OtpErlangRef extends OtpErlangObject {
     }
 
     /**
-     * Get the id number from the ref. Old style refs have only one id number. If this is
-     * a new style ref, the first id number is returned.
+     * Get the id number from the ref. Old style refs have only one id number.
+     * If this is a new style ref, the first id number is returned.
      *
      * @return the id number from the ref.
      */
@@ -168,8 +175,9 @@ public class OtpErlangRef extends OtpErlangObject {
     }
 
     /**
-     * Get the array of id numbers from the ref. If this is an old style ref, the array is
-     * of length 1. If this is a new style ref, the array has length 3-5.
+     * Get the array of id numbers from the ref. If this is an old style ref,
+     * the array is of length 1. If this is a new style ref, the array has
+     * length 3-5.
      *
      * @return the array of id numbers from the ref.
      */
@@ -214,8 +222,8 @@ public class OtpErlangRef extends OtpErlangObject {
     public String toString() {
         String s = "#Ref<" + node;
 
-        for (final int id : ids) {
-            s += "." + id;
+        for (int i = 0; i < ids.length; i++) {
+            s += "." + ids[i];
         }
 
         s += ">";
@@ -235,9 +243,9 @@ public class OtpErlangRef extends OtpErlangObject {
     }
 
     /**
-     * Determine if two refs are equal. Refs are equal if their components are equal. New
-     * refs and old refs are considered equal if the node, creation and first id numnber
-     * are equal.
+     * Determine if two refs are equal. Refs are equal if their components are
+     * equal. New refs and old refs are considered equal if the node, creation
+     * and first id number are equal.
      *
      * @param o
      *            the other ref to compare to.
@@ -252,7 +260,7 @@ public class OtpErlangRef extends OtpErlangObject {
 
         final OtpErlangRef ref = (OtpErlangRef) o;
 
-        if ((!node.equals(ref.node()) || (creation != ref.creation()))) {
+        if (!(node.equals(ref.node()) && creation == ref.creation())) {
             return false;
         }
 
@@ -263,7 +271,8 @@ public class OtpErlangRef extends OtpErlangObject {
                         return false;
                     }
                 }
-            } else {
+            }
+            else {
                 for (int i = ids.length; i < ref.ids.length; i++) {
                     if (ref.ids[i] != 0) {
                         return false;
@@ -280,7 +289,8 @@ public class OtpErlangRef extends OtpErlangObject {
     }
 
     /**
-     * Compute the hashCode value for a given ref. This function is compatible with equal.
+     * Compute the hashCode value for a given ref. This function is compatible
+     * with equal.
      *
      * @return the hashCode of the node.
      **/

--- a/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpErlangShort.java
+++ b/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpErlangShort.java
@@ -3,15 +3,17 @@
  *
  * Copyright Ericsson AB 2000-2016. All Rights Reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
- * file except in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under
- * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * %CopyrightEnd%
  */
@@ -35,15 +37,15 @@ public class OtpErlangShort extends OtpErlangLong {
     }
 
     /**
-     * Create an Erlang integer from a stream containing an integer encoded in Erlang
-     * external format.
+     * Create an Erlang integer from a stream containing an integer encoded in
+     * Erlang external format.
      *
      * @param buf
      *            the stream containing the encoded value.
      *
      * @exception OtpErlangDecodeException
-     *                if the buffer does not contain a valid external representation of an
-     *                Erlang integer.
+     *                if the buffer does not contain a valid external
+     *                representation of an Erlang integer.
      *
      * @exception OtpErlangRangeException
      *                if the value is too large to be represented as a short.

--- a/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpErlangString.java
+++ b/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpErlangString.java
@@ -3,15 +3,17 @@
  *
  * Copyright Ericsson AB 2000-2016. All Rights Reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
- * file except in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under
- * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * %CopyrightEnd%
  */
@@ -41,8 +43,8 @@ public class OtpErlangString extends OtpErlangObject {
      * @throws OtpErlangException
      *             for non-proper and non-integer lists.
      * @throws OtpErlangRangeException
-     *             if an integer in the list is not a valid Unicode code point according
-     *             to Erlang.
+     *             if an integer in the list is not a valid Unicode code point
+     *             according to Erlang.
      */
     public OtpErlangString(final OtpErlangList list) throws OtpErlangException {
         final String s = list.stringValue();
@@ -57,25 +59,26 @@ public class OtpErlangString extends OtpErlangObject {
     }
 
     /**
-     * Create an Erlang string from a stream containing a string encoded in Erlang
-     * external format.
+     * Create an Erlang string from a stream containing a string encoded in
+     * Erlang external format.
      *
      * @param buf
      *            the stream containing the encoded string.
      *
      * @exception OtpErlangDecodeException
-     *                if the buffer does not contain a valid external representation of an
-     *                Erlang string.
+     *                if the buffer does not contain a valid external
+     *                representation of an Erlang string.
      */
-    public OtpErlangString(final OtpInputStream buf) throws OtpErlangDecodeException {
+    public OtpErlangString(final OtpInputStream buf)
+            throws OtpErlangDecodeException {
         str = buf.read_string();
     }
 
     /**
      * Get the actual string contained in this object.
      *
-     * @return the raw string contained in this object, without regard to Erlang quoting
-     *         rules.
+     * @return the raw string contained in this object, without regard to Erlang
+     *         quoting rules.
      *
      * @see #toString
      */
@@ -100,7 +103,8 @@ public class OtpErlangString extends OtpErlangObject {
      * Convert this string to the equivalent Erlang external representation.
      *
      * @param buf
-     *            an output stream to which the encoded string should be written.
+     *            an output stream to which the encoded string should be
+     *            written.
      */
 
     @Override
@@ -109,15 +113,15 @@ public class OtpErlangString extends OtpErlangObject {
     }
 
     /**
-     * Determine if two strings are equal. They are equal if they represent the same
-     * sequence of characters. This method can be used to compare OtpErlangStrings with
-     * each other and with Strings.
+     * Determine if two strings are equal. They are equal if they represent the
+     * same sequence of characters. This method can be used to compare
+     * OtpErlangStrings with each other and with Strings.
      *
      * @param o
      *            the OtpErlangString or String to compare to.
      *
-     * @return true if the strings consist of the same sequence of characters, false
-     *         otherwise.
+     * @return true if the strings consist of the same sequence of characters,
+     *         false otherwise.
      */
 
     @Override
@@ -142,7 +146,8 @@ public class OtpErlangString extends OtpErlangObject {
      * @param s
      *            a String to convert to an Unicode code point array
      *
-     * @return the corresponding array of integers representing Unicode code points
+     * @return the corresponding array of integers representing Unicode code
+     *         points
      */
 
     public static int[] stringToCodePoints(final String s) {
@@ -158,8 +163,9 @@ public class OtpErlangString extends OtpErlangObject {
     }
 
     /**
-     * Validate a code point according to Erlang definition; Unicode 3.0. That is; valid
-     * in the range U+0..U+10FFFF, but not in the range U+D800..U+DFFF (surrogat pairs).
+     * Validate a code point according to Erlang definition; Unicode 3.0. That
+     * is; valid in the range U+0..U+10FFFF, but not in the range U+D800..U+DFFF
+     * (surrogat pairs).
      *
      * @param cp
      *            the code point value to validate
@@ -176,8 +182,8 @@ public class OtpErlangString extends OtpErlangObject {
     }
 
     /**
-     * Construct a String from a Latin-1 (ISO-8859-1) encoded byte array, if Latin-1 is
-     * available, otherwise use the default encoding.
+     * Construct a String from a Latin-1 (ISO-8859-1) encoded byte array, if
+     * Latin-1 is available, otherwise use the default encoding.
      *
      */
     public static String newString(final byte[] bytes) {

--- a/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpErlangTuple.java
+++ b/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpErlangTuple.java
@@ -3,27 +3,30 @@
  *
  * Copyright Ericsson AB 2000-2016. All Rights Reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
- * file except in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under
- * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * %CopyrightEnd%
  */
 package com.ericsson.otp.erlang;
 
 /**
- * Provides a Java representation of Erlang tuples. Tuples are created from one or more
- * arbitrary Erlang terms.
+ * Provides a Java representation of Erlang tuples. Tuples are created from one
+ * or more arbitrary Erlang terms.
  *
  * <p>
- * The arity of the tuple is the number of elements it contains. Elements are indexed from
- * 0 to (arity-1) and can be retrieved individually by using the appropriate index.
+ * The arity of the tuple is the number of elements it contains. Elements are
+ * indexed from 0 to (arity-1) and can be retrieved individually by using the
+ * appropriate index.
  */
 public class OtpErlangTuple extends OtpErlangObject {
     // don't change this!
@@ -44,7 +47,8 @@ public class OtpErlangTuple extends OtpErlangObject {
      */
     public OtpErlangTuple(final OtpErlangObject elem) {
         if (elem == null) {
-            throw new java.lang.IllegalArgumentException("Tuple element cannot be null");
+            throw new java.lang.IllegalArgumentException(
+                    "Tuple element cannot be null");
         }
         elems = new OtpErlangObject[] { elem };
     }
@@ -78,7 +82,8 @@ public class OtpErlangTuple extends OtpErlangObject {
     public OtpErlangTuple(final OtpErlangObject[] elems, final int start,
             final int count) {
         if (elems == null) {
-            throw new java.lang.IllegalArgumentException("Tuple content can't be null");
+            throw new java.lang.IllegalArgumentException(
+                    "Tuple content can't be null");
         } else if (count < 1) {
             this.elems = NO_ELEMENTS;
         } else {
@@ -88,23 +93,26 @@ public class OtpErlangTuple extends OtpErlangObject {
                     this.elems[i] = elems[start + i];
                 } else {
                     throw new java.lang.IllegalArgumentException(
-                            "Tuple element cannot be null (element" + (start + i) + ")");
+                            "Tuple element cannot be null (element"
+                                    + (start + i) + ")");
                 }
             }
         }
     }
 
     /**
-     * Create a tuple from a stream containing an tuple encoded in Erlang external format.
+     * Create a tuple from a stream containing an tuple encoded in Erlang
+     * external format.
      *
      * @param buf
      *            the stream containing the encoded tuple.
      *
      * @exception OtpErlangDecodeException
-     *                if the buffer does not contain a valid external representation of an
-     *                Erlang tuple.
+     *                if the buffer does not contain a valid external
+     *                representation of an Erlang tuple.
      */
-    public OtpErlangTuple(final OtpInputStream buf) throws OtpErlangDecodeException {
+    public OtpErlangTuple(final OtpInputStream buf)
+            throws OtpErlangDecodeException {
         final int arity = buf.read_tuple_head();
 
         if (arity > 0) {
@@ -131,8 +139,8 @@ public class OtpErlangTuple extends OtpErlangObject {
      * Get the specified element from the tuple.
      *
      * @param i
-     *            the index of the requested element. Tuple elements are numbered as array
-     *            elements, starting at 0.
+     *            the index of the requested element. Tuple elements are
+     *            numbered as array elements, starting at 0.
      *
      * @return the requested element, of null if i is not a valid element index.
      */
@@ -197,13 +205,14 @@ public class OtpErlangTuple extends OtpErlangObject {
     }
 
     /**
-     * Determine if two tuples are equal. Tuples are equal if they have the same arity and
-     * all of the elements are equal.
+     * Determine if two tuples are equal. Tuples are equal if they have the same
+     * arity and all of the elements are equal.
      *
      * @param o
      *            the tuple to compare to.
      *
-     * @return true if the tuples have the same arity and all the elements are equal.
+     * @return true if the tuples have the same arity and all the elements are
+     *         equal.
      */
     @Override
     public boolean equals(final Object o) {
@@ -247,7 +256,7 @@ public class OtpErlangTuple extends OtpErlangObject {
 
     @Override
     public <T> OtpErlangObject bind(final T binds) throws OtpErlangException {
-        final OtpErlangTuple tuple = (OtpErlangTuple) clone();
+        final OtpErlangTuple tuple = (OtpErlangTuple) this.clone();
         final int a = tuple.elems.length;
         for (int i = 0; i < a; i++) {
             final OtpErlangObject e = tuple.elems[i];

--- a/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpErlangUInt.java
+++ b/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpErlangUInt.java
@@ -3,15 +3,17 @@
  *
  * Copyright Ericsson AB 2000-2016. All Rights Reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
- * file except in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under
- * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * %CopyrightEnd%
  */
@@ -40,19 +42,19 @@ public class OtpErlangUInt extends OtpErlangLong {
     }
 
     /**
-     * Create an Erlang integer from a stream containing an integer encoded in Erlang
-     * external format.
+     * Create an Erlang integer from a stream containing an integer encoded in
+     * Erlang external format.
      *
      * @param buf
      *            the stream containing the encoded value.
      *
      * @exception OtpErlangDecodeException
-     *                if the buffer does not contain a valid external representation of an
-     *                Erlang integer.
+     *                if the buffer does not contain a valid external
+     *                representation of an Erlang integer.
      *
      * @exception OtpErlangRangeException
-     *                if the value is too large to be represented as an int, or the value
-     *                is negative.
+     *                if the value is too large to be represented as an int, or
+     *                the value is negative.
      */
     public OtpErlangUInt(final OtpInputStream buf)
             throws OtpErlangRangeException, OtpErlangDecodeException {

--- a/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpErlangUShort.java
+++ b/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpErlangUShort.java
@@ -3,15 +3,17 @@
  *
  * Copyright Ericsson AB 2000-2016. All Rights Reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
- * file except in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under
- * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * %CopyrightEnd%
  */
@@ -40,19 +42,19 @@ public class OtpErlangUShort extends OtpErlangLong {
     }
 
     /**
-     * Create an Erlang integer from a stream containing an integer encoded in Erlang
-     * external format.
+     * Create an Erlang integer from a stream containing an integer encoded in
+     * Erlang external format.
      *
      * @param buf
      *            the stream containing the encoded value.
      *
      * @exception OtpErlangDecodeException
-     *                if the buffer does not contain a valid external representation of an
-     *                Erlang integer.
+     *                if the buffer does not contain a valid external
+     *                representation of an Erlang integer.
      *
      * @exception OtpErlangRangeException
-     *                if the value is too large to be represented as a short, or the value
-     *                is negative.
+     *                if the value is too large to be represented as a short, or
+     *                the value is negative.
      */
     public OtpErlangUShort(final OtpInputStream buf)
             throws OtpErlangRangeException, OtpErlangDecodeException {

--- a/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpException.java
+++ b/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpException.java
@@ -3,15 +3,17 @@
  *
  * Copyright Ericsson AB 2000-2016. All Rights Reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
- * file except in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under
- * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * %CopyrightEnd%
  */
@@ -27,6 +29,7 @@ public abstract class OtpException extends Exception {
      * Provides no message.
      */
     public OtpException() {
+        super();
     }
 
     /**

--- a/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpExternal.java
+++ b/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpExternal.java
@@ -1,24 +1,27 @@
 /*
  * %CopyrightBegin%
  *
- * Copyright Ericsson AB 2000-2016. All Rights Reserved.
+ * Copyright Ericsson AB 2000-2021. All Rights Reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
- * file except in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under
- * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * %CopyrightEnd%
  */
 package com.ericsson.otp.erlang;
 
 /**
- * Provides a collection of constants used when encoding and decoding Erlang terms.
+ * Provides a collection of constants used when encoding and decoding Erlang
+ * terms.
  */
 public class OtpExternal {
     // no constructor

--- a/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpGenericTransportFactory.java
+++ b/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpGenericTransportFactory.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2022 Jérôme de Bretagne
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * %ExternalCopyright%
+ */
+
+package com.ericsson.otp.erlang;
+
+import java.io.IOException;
+import java.net.InetAddress;
+
+/**
+ * Transport factory abstract class used to create client-side and server-side
+ * transport instances defined using generic peers and local nodes (instead of
+ * a host + port combination as expected in the base OtpTransportFactory).
+ *
+ * It allows the creation of a transport using Unix Domain Sockets for example.
+ *
+ * OtpGenericTransportFactory is created as a subclass of OtpTransportFactory
+ * to keep backwards compatibility and ease the integration within existing
+ * Jinterface code, but in practice it doesn't support the 3 original methods.
+ */
+public abstract class OtpGenericTransportFactory implements OtpTransportFactory {
+
+    /**
+     * Create an instance of a client-side {@link OtpTransport}
+     *
+     * @param peer
+     *            the peer identifying the server to connect to
+     *
+     * @return a new transport object
+     *
+     * @throws IOException
+     */
+    public abstract OtpTransport createTransport(final OtpPeer peer)
+            throws IOException;
+
+    /**
+     * Create an instance of a server-side {@link OtpServerTransport}
+     *
+     * @param node
+     *            the local node identifying the transport to create server-side
+     *
+     * @return a new transport object
+     *
+     * @throws IOException
+     */
+    public abstract OtpServerTransport createServerTransport(final OtpLocalNode node)
+            throws IOException;
+
+
+    /**
+     * Implement the 3 original methods by throwing an exception as the usage
+     * of a port is not supported by this subclass of OtpTransportFactory.
+     */
+    @Override public OtpTransport createTransport(String addr, int port)
+            throws IOException {
+        throw new IOException("Method createTransport(String, int) " +
+                              "not applicable for OtpGenericTransportFactory");
+    }
+
+    @Override public OtpTransport createTransport(final InetAddress addr, final int port)
+            throws IOException {
+        throw new IOException("Method createTransport(InetAddress, int) " +
+                              "not applicable for OtpGenericTransportFactory");
+    }
+
+    @Override public OtpServerTransport createServerTransport(final int port)
+            throws IOException {
+        throw new IOException("Method createServerTransport(int) " +
+                              "not applicable for OtpGenericTransportFactory");
+    }
+
+}
+

--- a/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpInputStream.java
+++ b/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpInputStream.java
@@ -1,17 +1,19 @@
 /*
  * %CopyrightBegin%
  *
- * Copyright Ericsson AB 2000-2016. All Rights Reserved.
+ * Copyright Ericsson AB 2000-2021. All Rights Reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
- * file except in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under
- * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * %CopyrightEnd%
  */
@@ -26,8 +28,8 @@ import java.util.Arrays;
  * Provides a stream for decoding Erlang terms from external format.
  *
  * <p>
- * Note that this class is not synchronized, if you need synchronization you must provide
- * it yourself.
+ * Note that this class is not synchronized, if you need synchronization you
+ * must provide it yourself.
  */
 public class OtpInputStream extends ByteArrayInputStream {
 
@@ -53,8 +55,8 @@ public class OtpInputStream extends ByteArrayInputStream {
     }
 
     /**
-     * Create a stream from a buffer containing encoded Erlang terms at the given offset
-     * and length.
+     * Create a stream from a buffer containing encoded Erlang terms at the
+     * given offset and length.
      *
      * @param flags
      */
@@ -77,10 +79,10 @@ public class OtpInputStream extends ByteArrayInputStream {
      * Set the current position in the stream.
      *
      * @param pos
-     *            the position to move to in the stream. If pos indicates a position
-     *            beyond the end of the stream, the position is move to the end of the
-     *            stream instead. If pos is negative, the position is moved to the
-     *            beginning of the stream instead.
+     *            the position to move to in the stream. If pos indicates a
+     *            position beyond the end of the stream, the position is move to
+     *            the end of the stream instead. If pos is negative, the
+     *            position is moved to the beginning of the stream instead.
      *
      * @return the previous position in the stream.
      */
@@ -100,8 +102,8 @@ public class OtpInputStream extends ByteArrayInputStream {
     }
 
     /**
-     * Read an array of bytes from the stream. The method reads at most buf.length bytes
-     * from the input stream.
+     * Read an array of bytes from the stream. The method reads at most
+     * buf.length bytes from the input stream.
      *
      * @return the number of bytes read.
      *
@@ -113,8 +115,8 @@ public class OtpInputStream extends ByteArrayInputStream {
     }
 
     /**
-     * Read an array of bytes from the stream. The method reads at most len bytes from the
-     * input stream into offset off of the buffer.
+     * Read an array of bytes from the stream. The method reads at most len
+     * bytes from the input stream into offset off of the buffer.
      *
      * @return the number of bytes read.
      *
@@ -141,7 +143,8 @@ public class OtpInputStream extends ByteArrayInputStream {
     }
 
     /**
-     * Look ahead one position in the stream without consuming the byte found there.
+     * Look ahead one position in the stream without consuming the byte found
+     * there.
      *
      * @return the next byte in the stream, as an integer.
      *
@@ -231,8 +234,8 @@ public class OtpInputStream extends ByteArrayInputStream {
         } catch (final IOException e) {
             throw new OtpErlangDecodeException("Cannot read from input stream");
         }
-        return (b[0] << 24 & 0xff000000) + (b[1] << 16 & 0xff0000) + (b[2] << 8 & 0xff00)
-                + (b[3] & 0xff);
+        return (b[0] << 24 & 0xff000000) + (b[1] << 16 & 0xff0000)
+                + (b[2] << 8 & 0xff00) + (b[3] & 0xff);
     }
 
     /**
@@ -244,9 +247,9 @@ public class OtpInputStream extends ByteArrayInputStream {
      *                if the next byte cannot be read.
      */
     public long read8BE() throws OtpErlangDecodeException {
-        final long high = read4BE();
-        final long low = read4BE();
-        return high << 32 | low & 0xffffffff;
+        long high = read4BE();
+        long low = read4BE();
+        return (high << 32) | (low & 0xffffffff);
     }
 
     /**
@@ -282,8 +285,8 @@ public class OtpInputStream extends ByteArrayInputStream {
         } catch (final IOException e) {
             throw new OtpErlangDecodeException("Cannot read from input stream");
         }
-        return (b[3] << 24 & 0xff000000) + (b[2] << 16 & 0xff0000) + (b[1] << 8 & 0xff00)
-                + (b[0] & 0xff);
+        return (b[3] << 24 & 0xff000000) + (b[2] << 16 & 0xff0000)
+                + (b[1] << 8 & 0xff00) + (b[0] & 0xff);
     }
 
     /**
@@ -340,8 +343,8 @@ public class OtpInputStream extends ByteArrayInputStream {
     /**
      * Read an Erlang atom from the stream and interpret the value as a boolean.
      *
-     * @return true if the atom at the current position in the stream contains the value
-     *         'true' (ignoring case), false otherwise.
+     * @return true if the atom at the current position in the stream contains
+     *         the value 'true' (ignoring case), false otherwise.
      *
      * @exception OtpErlangDecodeException
      *                if the next term in the stream is not an atom.
@@ -376,12 +379,13 @@ public class OtpInputStream extends ByteArrayInputStream {
             try {
                 atom = new String(strbuf, "ISO-8859-1");
             } catch (final java.io.UnsupportedEncodingException e) {
-                throw new OtpErlangDecodeException("Failed to decode ISO-8859-1 atom");
+                throw new OtpErlangDecodeException(
+                        "Failed to decode ISO-8859-1 atom");
             }
             if (atom.length() > OtpExternal.maxAtomLength) {
                 /*
-                 * Throwing an exception would be better I think, but truncation seems to
-                 * be the way it has been done in other parts of OTP...
+                 * Throwing an exception would be better I think, but truncation
+                 * seems to be the way it has been done in other parts of OTP...
                  */
                 atom = atom.substring(0, OtpExternal.maxAtomLength);
             }
@@ -399,12 +403,13 @@ public class OtpInputStream extends ByteArrayInputStream {
             try {
                 atom = new String(strbuf, "UTF-8");
             } catch (final java.io.UnsupportedEncodingException e) {
-                throw new OtpErlangDecodeException("Failed to decode UTF-8 atom");
+                throw new OtpErlangDecodeException(
+                        "Failed to decode UTF-8 atom");
             }
             if (atom.codePointCount(0, atom.length()) > OtpExternal.maxAtomLength) {
                 /*
-                 * Throwing an exception would be better I think, but truncation seems to
-                 * be the way it has been done in other parts of OTP...
+                 * Throwing an exception would be better I think, but truncation
+                 * seems to be the way it has been done in other parts of OTP...
                  */
                 final int[] cps = OtpErlangString.stringToCodePoints(atom);
                 atom = new String(cps, 0, OtpExternal.maxAtomLength);
@@ -413,8 +418,9 @@ public class OtpInputStream extends ByteArrayInputStream {
 
         default:
             throw new OtpErlangDecodeException(
-                    "wrong tag encountered, expected " + OtpExternal.atomTag + ", or "
-                            + OtpExternal.atomUtf8Tag + ", got " + tag);
+                    "wrong tag encountered, expected " + OtpExternal.atomTag
+                            + ", or " + OtpExternal.atomUtf8Tag + ", got "
+                            + tag);
         }
 
         return atom;
@@ -436,8 +442,9 @@ public class OtpInputStream extends ByteArrayInputStream {
         tag = read1skip_version();
 
         if (tag != OtpExternal.binTag) {
-            throw new OtpErlangDecodeException("Wrong tag encountered, expected "
-                    + OtpExternal.binTag + ", got " + tag);
+            throw new OtpErlangDecodeException(
+                    "Wrong tag encountered, expected " + OtpExternal.binTag
+                            + ", got " + tag);
         }
 
         len = read4BE();
@@ -452,15 +459,16 @@ public class OtpInputStream extends ByteArrayInputStream {
      * Read an Erlang bitstr from the stream.
      *
      * @param pad_bits
-     *            an int array whose first element will be set to the number of pad bits
-     *            in the last byte.
+     *            an int array whose first element will be set to the number of
+     *            pad bits in the last byte.
      *
      * @return a byte array containing the value of the bitstr.
      *
      * @exception OtpErlangDecodeException
      *                if the next term in the stream is not a bitstr.
      */
-    public byte[] read_bitstr(final int pad_bits[]) throws OtpErlangDecodeException {
+    public byte[] read_bitstr(final int pad_bits[])
+            throws OtpErlangDecodeException {
         int tag;
         int len;
         byte[] bin;
@@ -468,8 +476,9 @@ public class OtpInputStream extends ByteArrayInputStream {
         tag = read1skip_version();
 
         if (tag != OtpExternal.bitBinTag) {
-            throw new OtpErlangDecodeException("Wrong tag encountered, expected "
-                    + OtpExternal.bitBinTag + ", got " + tag);
+            throw new OtpErlangDecodeException(
+                    "Wrong tag encountered, expected " + OtpExternal.bitBinTag
+                            + ", got " + tag);
         }
 
         len = read4BE();
@@ -535,7 +544,8 @@ public class OtpInputStream extends ByteArrayInputStream {
             epos = str.indexOf('e', 0);
 
             if (epos < 0) {
-                throw new OtpErlangDecodeException("Invalid float format: '" + str + "'");
+                throw new OtpErlangDecodeException("Invalid float format: '"
+                        + str + "'");
             }
 
             // remove the sign from the exponent, if positive
@@ -552,8 +562,9 @@ public class OtpInputStream extends ByteArrayInputStream {
             return val.doubleValue();
         }
         default:
-            throw new OtpErlangDecodeException("Wrong tag encountered, expected "
-                    + OtpExternal.newFloatTag + ", got " + tag);
+            throw new OtpErlangDecodeException(
+                    "Wrong tag encountered, expected "
+                            + OtpExternal.newFloatTag + ", got " + tag);
         }
     }
 
@@ -570,7 +581,8 @@ public class OtpInputStream extends ByteArrayInputStream {
         final byte i = (byte) l;
 
         if (l != i) {
-            throw new OtpErlangDecodeException("Value does not fit in byte: " + l);
+            throw new OtpErlangDecodeException("Value does not fit in byte: "
+                    + l);
         }
 
         return i;
@@ -582,15 +594,16 @@ public class OtpInputStream extends ByteArrayInputStream {
      * @return the character value.
      *
      * @exception OtpErlangDecodeException
-     *                if the next term in the stream is not an integer that can be
-     *                represented as a char.
+     *                if the next term in the stream is not an integer that can
+     *                be represented as a char.
      */
     public char read_char() throws OtpErlangDecodeException {
         final long l = this.read_long(true);
         final char i = (char) l;
 
         if (l != (i & 0xffffL)) {
-            throw new OtpErlangDecodeException("Value does not fit in char: " + l);
+            throw new OtpErlangDecodeException("Value does not fit in char: "
+                    + l);
         }
 
         return i;
@@ -602,15 +615,16 @@ public class OtpInputStream extends ByteArrayInputStream {
      * @return the integer value.
      *
      * @exception OtpErlangDecodeException
-     *                if the next term in the stream cannot be represented as a positive
-     *                integer.
+     *                if the next term in the stream cannot be represented as a
+     *                positive integer.
      */
     public int read_uint() throws OtpErlangDecodeException {
         final long l = this.read_long(true);
         final int i = (int) l;
 
         if (l != (i & 0xFFFFffffL)) {
-            throw new OtpErlangDecodeException("Value does not fit in uint: " + l);
+            throw new OtpErlangDecodeException("Value does not fit in uint: "
+                    + l);
         }
 
         return i;
@@ -622,14 +636,16 @@ public class OtpInputStream extends ByteArrayInputStream {
      * @return the integer value.
      *
      * @exception OtpErlangDecodeException
-     *                if the next term in the stream cannot be represented as an integer.
+     *                if the next term in the stream cannot be represented as
+     *                an integer.
      */
     public int read_int() throws OtpErlangDecodeException {
         final long l = this.read_long(false);
         final int i = (int) l;
 
         if (l != i) {
-            throw new OtpErlangDecodeException("Value does not fit in int: " + l);
+            throw new OtpErlangDecodeException("Value does not fit in int: "
+                    + l);
         }
 
         return i;
@@ -641,15 +657,16 @@ public class OtpInputStream extends ByteArrayInputStream {
      * @return the short value.
      *
      * @exception OtpErlangDecodeException
-     *                if the next term in the stream cannot be represented as a positive
-     *                short.
+     *                if the next term in the stream cannot be represented as a
+     *                positive short.
      */
     public short read_ushort() throws OtpErlangDecodeException {
         final long l = this.read_long(true);
         final short i = (short) l;
 
         if (l != (i & 0xffffL)) {
-            throw new OtpErlangDecodeException("Value does not fit in ushort: " + l);
+            throw new OtpErlangDecodeException("Value does not fit in ushort: "
+                    + l);
         }
 
         return i;
@@ -661,14 +678,16 @@ public class OtpInputStream extends ByteArrayInputStream {
      * @return the short value.
      *
      * @exception OtpErlangDecodeException
-     *                if the next term in the stream cannot be represented as a short.
+     *                if the next term in the stream cannot be represented as a
+     *                short.
      */
     public short read_short() throws OtpErlangDecodeException {
         final long l = this.read_long(false);
         final short i = (short) l;
 
         if (l != i) {
-            throw new OtpErlangDecodeException("Value does not fit in short: " + l);
+            throw new OtpErlangDecodeException("Value does not fit in short: "
+                    + l);
         }
 
         return i;
@@ -680,8 +699,8 @@ public class OtpInputStream extends ByteArrayInputStream {
      * @return the long value.
      *
      * @exception OtpErlangDecodeException
-     *                if the next term in the stream cannot be represented as a positive
-     *                long.
+     *                if the next term in the stream cannot be represented as a
+     *                positive long.
      */
     public long read_ulong() throws OtpErlangDecodeException {
         return this.read_long(true);
@@ -693,13 +712,15 @@ public class OtpInputStream extends ByteArrayInputStream {
      * @return the long value.
      *
      * @exception OtpErlangDecodeException
-     *                if the next term in the stream cannot be represented as a long.
+     *                if the next term in the stream cannot be represented as a
+     *                long.
      */
     public long read_long() throws OtpErlangDecodeException {
         return this.read_long(false);
     }
 
-    public long read_long(final boolean unsigned) throws OtpErlangDecodeException {
+    public long read_long(final boolean unsigned)
+            throws OtpErlangDecodeException {
         final byte[] b = read_integer_byte_array();
         return OtpInputStream.byte_array_to_long(b, unsigned);
     }
@@ -728,7 +749,8 @@ public class OtpInputStream extends ByteArrayInputStream {
         case OtpExternal.intTag:
             nb = new byte[4];
             if (this.readN(nb) != 4) { // Big endian
-                throw new OtpErlangDecodeException("Cannot read from intput stream");
+                throw new OtpErlangDecodeException(
+                        "Cannot read from input stream");
             }
             break;
 
@@ -744,15 +766,16 @@ public class OtpInputStream extends ByteArrayInputStream {
                 sign = read1();
                 if (arity + 1 < 0) {
                     throw new OtpErlangDecodeException(
-                            "Value of largeBig does not fit in BigInteger, arity " + arity
-                                    + " sign " + sign);
+                            "Value of largeBig does not fit in BigInteger, arity "
+                                    + arity + " sign " + sign);
                 }
             }
             nb = new byte[arity + 1];
             // Value is read as little endian. The big end is augumented
             // with one zero byte to make the value 2's complement positive.
             if (this.readN(nb, 0, arity) != arity) {
-                throw new OtpErlangDecodeException("Cannot read from intput stream");
+                throw new OtpErlangDecodeException(
+                        "Cannot read from input stream");
             }
             // Reverse the array to make it big endian.
             for (int i = 0, j = nb.length; i < j--; i++) {
@@ -794,8 +817,8 @@ public class OtpInputStream extends ByteArrayInputStream {
             }
             break;
         case 4:
-            v = ((b[0] & 0xFF) << 24) + ((b[1] & 0xFF) << 16) + ((b[2] & 0xFF) << 8)
-                    + (b[3] & 0xFF);
+            v = ((b[0] & 0xFF) << 24) + ((b[1] & 0xFF) << 16)
+                    + ((b[2] & 0xFF) << 8) + (b[3] & 0xFF);
             v = (int) v; // Sign extend
             if (v < 0 && unsigned) {
                 throw new OtpErlangDecodeException("Value not unsigned: " + v);
@@ -807,24 +830,26 @@ public class OtpInputStream extends ByteArrayInputStream {
             // Skip non-essential leading bytes
             if (unsigned) {
                 if (c < 0) {
-                    throw new OtpErlangDecodeException(
-                            "Value not unsigned: " + Arrays.toString(b));
+                    throw new OtpErlangDecodeException("Value not unsigned: "
+                            + Arrays.toString(b));
                 }
                 while (b[i] == 0) {
                     i++; // Skip leading zero sign bytes
                 }
-            } else if (c == 0 || c == -1) { // Leading sign byte
-                i = 1;
-                // Skip all leading sign bytes
-                while (i < b.length && b[i] == c) {
-                    i++;
-                }
-                if (i < b.length) {
-                    // Check first non-sign byte to see if its sign
-                    // matches the whole number's sign. If not one more
-                    // byte is needed to represent the value.
-                    if (((c ^ b[i]) & 0x80) != 0) {
-                        i--;
+            } else {
+                if (c == 0 || c == -1) { // Leading sign byte
+                    i = 1;
+                    // Skip all leading sign bytes
+                    while (i < b.length && b[i] == c) {
+                        i++;
+                    }
+                    if (i < b.length) {
+                        // Check first non-sign byte to see if its sign
+                        // matches the whole number's sign. If not one more
+                        // byte is needed to represent the value.
+                        if (((c ^ b[i]) & 0x80) != 0) {
+                            i--;
+                        }
                     }
                 }
             }
@@ -943,20 +968,21 @@ public class OtpInputStream extends ByteArrayInputStream {
 
         tag = read1skip_version();
 
-        if (tag != OtpExternal.pidTag && tag != OtpExternal.newPidTag) {
+        if (tag != OtpExternal.pidTag &&
+	    tag != OtpExternal.newPidTag) {
             throw new OtpErlangDecodeException(
-                    "Wrong tag encountered, expected " + OtpExternal.pidTag + " or "
-                            + OtpExternal.newPidTag + ", got " + tag);
+                    "Wrong tag encountered, expected " + OtpExternal.pidTag
+		    + " or " + OtpExternal.newPidTag
+                            + ", got " + tag);
         }
 
         node = read_atom();
         id = read4BE();
         serial = read4BE();
-        if (tag == OtpExternal.pidTag) {
-            creation = read1();
-        } else {
-            creation = read4BE();
-        }
+	if (tag == OtpExternal.pidTag)
+	    creation = read1();
+	else
+	    creation = read4BE();
 
         return new OtpErlangPid(tag, node, id, serial, creation);
     }
@@ -977,23 +1003,27 @@ public class OtpInputStream extends ByteArrayInputStream {
 
         tag = read1skip_version();
 
-        if (tag != OtpExternal.portTag && tag != OtpExternal.newPortTag
-                && tag != OtpExternal.v4PortTag) {
-            throw new OtpErlangDecodeException("Wrong tag encountered, expected "
-                    + OtpExternal.portTag + ", " + OtpExternal.newPortTag + ", or "
-                    + OtpExternal.v4PortTag + ", got " + tag);
+        if (tag != OtpExternal.portTag &&
+	    tag != OtpExternal.newPortTag &&
+	    tag != OtpExternal.v4PortTag) {
+            throw new OtpErlangDecodeException(
+                    "Wrong tag encountered, expected " + OtpExternal.portTag
+		    + ", " + OtpExternal.newPortTag + ", or "
+                     + OtpExternal.v4PortTag + ", got " + tag);
         }
 
         node = read_atom();
         if (tag == OtpExternal.v4PortTag) {
             id = read8BE();
-            creation = read4BE();
-        } else if (tag == OtpExternal.newPortTag) {
+	    creation = read4BE();            
+        }
+        else if (tag == OtpExternal.newPortTag) {
+            id = (long) read4BE();
+	    creation = read4BE();
+        }
+        else {
             id = read4BE();
-            creation = read4BE();
-        } else {
-            id = read4BE();
-            creation = read1();
+	    creation = read1();
         }
 
         return new OtpErlangPort(tag, node, id, creation);
@@ -1026,14 +1056,14 @@ public class OtpInputStream extends ByteArrayInputStream {
         case OtpExternal.newerRefTag:
             final int arity = read2BE();
             if (arity > 5) {
-                throw new OtpErlangDecodeException("Ref arity " + arity + " too large ");
-            }
+		throw new OtpErlangDecodeException(
+		    "Ref arity " + arity + " too large ");
+	    }
             node = read_atom();
-            if (tag == OtpExternal.newRefTag) {
-                creation = read1();
-            } else {
-                creation = read4BE();
-            }
+	    if (tag == OtpExternal.newRefTag)
+		creation = read1();
+	    else
+		creation = read4BE();
 
             final int[] ids = new int[arity];
             for (int i = 0; i < arity; i++) {
@@ -1075,15 +1105,16 @@ public class OtpInputStream extends ByteArrayInputStream {
             for (int i = 0; i < nFreeVars; ++i) {
                 freeVars[i] = read_any();
             }
-            return new OtpErlangFun(pid, module, arity, md5, index, oldIndex, uniq,
-                    freeVars);
+            return new OtpErlangFun(pid, module, arity, md5, index, oldIndex,
+                    uniq, freeVars);
         } else {
             throw new OtpErlangDecodeException(
                     "Wrong tag encountered, expected fun, got " + tag);
         }
     }
 
-    public OtpErlangExternalFun read_external_fun() throws OtpErlangDecodeException {
+    public OtpErlangExternalFun read_external_fun()
+            throws OtpErlangDecodeException {
         final int tag = read1skip_version();
         if (tag != OtpExternal.externalFunTag) {
             throw new OtpErlangDecodeException(
@@ -1123,15 +1154,16 @@ public class OtpInputStream extends ByteArrayInputStream {
             for (int i = 0; i < len; i++) {
                 intbuf[i] = read_int();
                 if (!OtpErlangString.isValidCodePoint(intbuf[i])) {
-                    throw new OtpErlangDecodeException("Invalid CodePoint: " + intbuf[i]);
+                    throw new OtpErlangDecodeException("Invalid CodePoint: "
+                            + intbuf[i]);
                 }
             }
             read_nil();
             return new String(intbuf, 0, intbuf.length);
         default:
             throw new OtpErlangDecodeException(
-                    "Wrong tag encountered, expected " + OtpExternal.stringTag + " or "
-                            + OtpExternal.listTag + ", got " + tag);
+                    "Wrong tag encountered, expected " + OtpExternal.stringTag
+                            + " or " + OtpExternal.listTag + ", got " + tag);
         }
     }
 
@@ -1147,8 +1179,9 @@ public class OtpInputStream extends ByteArrayInputStream {
         final int tag = read1skip_version();
 
         if (tag != OtpExternal.compressedTag) {
-            throw new OtpErlangDecodeException("Wrong tag encountered, expected "
-                    + OtpExternal.compressedTag + ", got " + tag);
+            throw new OtpErlangDecodeException(
+                    "Wrong tag encountered, expected "
+                            + OtpExternal.compressedTag + ", got " + tag);
         }
 
         final int size = read4BE();
@@ -1163,8 +1196,8 @@ public class OtpInputStream extends ByteArrayInputStream {
                 curPos += curRead;
             }
             if (curPos != size) {
-                throw new OtpErlangDecodeException(
-                        "Decompression gave " + curPos + " bytes, not " + size);
+                throw new OtpErlangDecodeException("Decompression gave "
+                        + curPos + " bytes, not " + size);
             }
         } catch (final IOException e) {
             throw new OtpErlangDecodeException("Cannot read from input stream");
@@ -1181,8 +1214,8 @@ public class OtpInputStream extends ByteArrayInputStream {
      * @return the Erlang term.
      *
      * @exception OtpErlangDecodeException
-     *                if the stream does not contain a known Erlang type at the next
-     *                position.
+     *                if the stream does not contain a known Erlang type at the
+     *                next position.
      */
     public OtpErlangObject read_any() throws OtpErlangDecodeException {
         // calls one of the above functions, depending on o
@@ -1253,8 +1286,8 @@ public class OtpInputStream extends ByteArrayInputStream {
         case OtpExternal.funTag:
             return new OtpErlangFun(this);
 
-        case OtpExternal.externalFunTag:
-            return new OtpErlangExternalFun(this);
+	case OtpExternal.externalFunTag:
+	    return new OtpErlangExternalFun(this);
 
         default:
             throw new OtpErlangDecodeException("Unknown data type: " + tag);

--- a/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpLocalNode.java
+++ b/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpLocalNode.java
@@ -1,17 +1,19 @@
 /*
  * %CopyrightBegin%
  *
- * Copyright Ericsson AB 2000-2016. All Rights Reserved.
+ * Copyright Ericsson AB 2000-2021. All Rights Reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
- * file except in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under
- * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * %CopyrightEnd%
  */
@@ -39,7 +41,8 @@ public class OtpLocalNode extends AbstractNode {
     }
 
     /**
-     * Create a node with the given name, transport factory and the default cookie.
+     * Create a node with the given name, transport factory and the default
+     * cookie.
      */
     protected OtpLocalNode(final String node,
             final OtpTransportFactory transportFactory) {
@@ -103,14 +106,15 @@ public class OtpLocalNode extends AbstractNode {
     }
 
     /**
-     * Create an Erlang {@link OtpErlangPid pid}. Erlang pids are based upon some node
-     * specific information; this method creates a pid using the information in this node.
-     * Each call to this method produces a unique pid.
+     * Create an Erlang {@link OtpErlangPid pid}. Erlang pids are based upon
+     * some node specific information; this method creates a pid using the
+     * information in this node. Each call to this method produces a unique pid.
      *
      * @return an Erlang pid.
      */
     public synchronized OtpErlangPid createPid() {
-        final OtpErlangPid p = new OtpErlangPid(node, pidCount, serial, creation);
+        final OtpErlangPid p = new OtpErlangPid(node, pidCount, serial,
+                creation());
 
         pidCount++;
         if (pidCount > 0x7fff) {
@@ -126,16 +130,16 @@ public class OtpLocalNode extends AbstractNode {
     }
 
     /**
-     * Create an Erlang {@link OtpErlangPort port}. Erlang ports are based upon some node
-     * specific information; this method creates a port using the information in this
-     * node. Each call to this method produces a unique port. It may not be meaningful to
-     * create a port in a non-Erlang environment, but this method is provided for
-     * completeness.
+     * Create an Erlang {@link OtpErlangPort port}. Erlang ports are based upon
+     * some node specific information; this method creates a port using the
+     * information in this node. Each call to this method produces a unique
+     * port. It may not be meaningful to create a port in a non-Erlang
+     * environment, but this method is provided for completeness.
      *
      * @return an Erlang port.
      */
     public synchronized OtpErlangPort createPort() {
-        final OtpErlangPort p = new OtpErlangPort(node, portCount, creation);
+        final OtpErlangPort p = new OtpErlangPort(node, portCount, creation());
 
         portCount++;
         if (portCount > 0xfffffff) { /* 28 bits */
@@ -146,14 +150,15 @@ public class OtpLocalNode extends AbstractNode {
     }
 
     /**
-     * Create an Erlang {@link OtpErlangRef reference}. Erlang references are based upon
-     * some node specific information; this method creates a reference using the
-     * information in this node. Each call to this method produces a unique reference.
+     * Create an Erlang {@link OtpErlangRef reference}. Erlang references are
+     * based upon some node specific information; this method creates a
+     * reference using the information in this node. Each call to this method
+     * produces a unique reference.
      *
      * @return an Erlang reference.
      */
     public synchronized OtpErlangRef createRef() {
-        final OtpErlangRef r = new OtpErlangRef(node, refId, creation);
+        final OtpErlangRef r = new OtpErlangRef(node, refId, creation());
 
         // increment ref ids (3 ints: 18 + 32 + 32 bits)
         refId[0]++;

--- a/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpMD5.java
+++ b/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpMD5.java
@@ -3,15 +3,17 @@
  *
  * Copyright Ericsson AB 2000-2016. All Rights Reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
- * file except in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under
- * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * %CopyrightEnd%
  */
@@ -44,7 +46,8 @@ class OtpMD5 {
      * Has to be this large to avoid sign problems
      */
 
-    private final long state[] = { 0x67452301L, 0xefcdab89L, 0x98badcfeL, 0x10325476L };
+    private final long state[] = { 0x67452301L, 0xefcdab89L, 0x98badcfeL,
+            0x10325476L };
     private final long count[] = { 0L, 0L };
     private final int buffer[];
 
@@ -97,8 +100,8 @@ class OtpMD5 {
         return ~x & 0xFFFFFFFFL;
     }
 
-    private void to_buffer(final int to_start, final int[] from, final int from_start,
-            final int num) {
+    private void to_buffer(final int to_start, final int[] from,
+            final int from_start, final int num) {
         int ix = num;
         int to_ix = to_start;
         int from_ix = from_start;
@@ -147,8 +150,8 @@ class OtpMD5 {
 
     @SuppressWarnings("unused")
     private void dumpstate() {
-        System.out.println("state = {" + state[0] + ", " + state[1] + ", " + state[2]
-                + ", " + state[3] + "}");
+        System.out.println("state = {" + state[0] + ", " + state[1] + ", "
+                + state[2] + ", " + state[3] + "}");
         System.out.println("count = {" + count[0] + ", " + count[1] + "}");
         System.out.print("buffer = {");
         int i;
@@ -185,41 +188,42 @@ class OtpMD5 {
         return shl(x, (int) n) | shr(x, (int) (32 - n));
     }
 
-    private long FF(final long a, final long b, final long c, final long d, final long x,
-            final long s, final long ac) {
+    private long FF(final long a, final long b, final long c, final long d,
+            final long x, final long s, final long ac) {
         long tmp = plus(a, plus(plus(F(b, c, d), x), ac));
         tmp = ROTATE_LEFT(tmp, s);
         return plus(tmp, b);
     }
 
-    private long GG(final long a, final long b, final long c, final long d, final long x,
-            final long s, final long ac) {
+    private long GG(final long a, final long b, final long c, final long d,
+            final long x, final long s, final long ac) {
         long tmp = plus(a, plus(plus(G(b, c, d), x), ac));
         tmp = ROTATE_LEFT(tmp, s);
         return plus(tmp, b);
     }
 
-    private long HH(final long a, final long b, final long c, final long d, final long x,
-            final long s, final long ac) {
+    private long HH(final long a, final long b, final long c, final long d,
+            final long x, final long s, final long ac) {
         long tmp = plus(a, plus(plus(H(b, c, d), x), ac));
         tmp = ROTATE_LEFT(tmp, s);
         return plus(tmp, b);
     }
 
-    private long II(final long a, final long b, final long c, final long d, final long x,
-            final long s, final long ac) {
+    private long II(final long a, final long b, final long c, final long d,
+            final long x, final long s, final long ac) {
         long tmp = plus(a, plus(plus(I(b, c, d), x), ac));
         tmp = ROTATE_LEFT(tmp, s);
         return plus(tmp, b);
     }
 
-    private void decode(final long output[], final int input[], final int in_from,
-            final int len) {
+    private void decode(final long output[], final int input[],
+            final int in_from, final int len) {
         int i, j;
 
         for (i = 0, j = 0; j < len; i++, j += 4) {
             output[i] = input[j + in_from] | shl(input[j + in_from + 1], 8)
-                    | shl(input[j + in_from + 2], 16) | shl(input[j + in_from + 3], 24);
+                    | shl(input[j + in_from + 2], 16)
+                    | shl(input[j + in_from + 3], 24);
         }
     }
 

--- a/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpNode.java
+++ b/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpNode.java
@@ -1,17 +1,19 @@
 /*
  * %CopyrightBegin%
  *
- * Copyright Ericsson AB 2000-2016. All Rights Reserved.
+ * Copyright Ericsson AB 2000-2022. All Rights Reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
- * file except in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under
- * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * %CopyrightEnd%
  */
@@ -26,32 +28,36 @@ import java.util.Iterator;
 
 /**
  * <p>
- * Represents a local OTP node. This class is used when you do not wish to manage
- * connections yourself - outgoing connections are established as needed, and incoming
- * connections accepted automatically. This class supports the use of a mailbox API for
- * communication, while management of the underlying communication mechanism is automatic
- * and hidden from the application programmer.
+ * Represents a local OTP node. This class is used when you do not wish to
+ * manage connections yourself - outgoing connections are established as needed,
+ * and incoming connections accepted automatically. This class supports the use
+ * of a mailbox API for communication, while management of the underlying
+ * communication mechanism is automatic and hidden from the application
+ * programmer.
  * </p>
  *
  * <p>
- * Once an instance of this class has been created, obtain one or more mailboxes in order
- * to send or receive messages. The first message sent to a given node will cause a
- * connection to be set up to that node. Any messages received will be delivered to the
- * appropriate mailboxes.
+ * Once an instance of this class has been created, obtain one or more mailboxes
+ * in order to send or receive messages. The first message sent to a given node
+ * will cause a connection to be set up to that node. Any messages received will
+ * be delivered to the appropriate mailboxes.
  * </p>
  *
  * <p>
- * To shut down the node, call {@link #close close()}. This will prevent the node from
- * accepting additional connections and it will cause all existing connections to be
- * closed. Any unread messages in existing mailboxes can still be read, however no new
- * messages will be delivered to the mailboxes.
+ * To shut down the node, call {@link #close close()}. This will prevent the
+ * node from accepting additional connections and it will cause all existing
+ * connections to be closed. Any unread messages in existing mailboxes can still
+ * be read, however no new messages will be delivered to the mailboxes.
  * </p>
  *
  * <p>
- * Note that the use of this class requires that Epmd (Erlang Port Mapper Daemon) is
- * running on each cooperating host. This class does not start Epmd automatically as
- * Erlang does, you must start it manually or through some other means. See the Erlang
- * documentation for more information about this.
+ * Note that the use of this class requires that Epmd (Erlang Port Mapper
+ * Daemon) is running on each cooperating host, except when using a transport
+ * factory extending the OtpGenericTransportFactory abstract class.
+ *
+ * This class does not start Epmd automatically as Erlang does, you must start
+ * it manually or through some other means. See the Erlang documentation for
+ * more information about this.
  * </p>
  */
 public class OtpNode extends OtpLocalNode {
@@ -74,14 +80,15 @@ public class OtpNode extends OtpLocalNode {
 
     /**
      * <p>
-     * Create a node using the default cookie. The default cookie is found by reading the
-     * first line of the .erlang.cookie file in the user's home directory. The home
-     * directory is obtained from the System property "user.home".
+     * Create a node using the default cookie. The default cookie is found by
+     * reading the first line of the .erlang.cookie file in the user's home
+     * directory. The home directory is obtained from the System property
+     * "user.home".
      * </p>
      *
      * <p>
-     * If the file does not exist, an empty string is used. This method makes no attempt
-     * to create the file.
+     * If the file does not exist, an empty string is used. This method makes no
+     * attempt to create the file.
      * </p>
      *
      * @param node
@@ -99,14 +106,15 @@ public class OtpNode extends OtpLocalNode {
 
     /**
      * <p>
-     * Create a node using the default cookie. The default cookie is found by reading the
-     * first line of the .erlang.cookie file in the user's home directory. The home
-     * directory is obtained from the System property "user.home".
+     * Create a node using the default cookie. The default cookie is found by
+     * reading the first line of the .erlang.cookie file in the user's home
+     * directory. The home directory is obtained from the System property
+     * "user.home".
      * </p>
      *
      * <p>
-     * If the file does not exist, an empty string is used. This method makes no attempt
-     * to create the file.
+     * If the file does not exist, an empty string is used. This method makes no
+     * attempt to create the file.
      * </p>
      *
      * @param node
@@ -119,11 +127,18 @@ public class OtpNode extends OtpLocalNode {
      *                if communication could not be initialized.
      *
      */
-    public OtpNode(final String node, final OtpTransportFactory transportFactory)
-            throws IOException {
+    public OtpNode(final String node,
+            final OtpTransportFactory transportFactory) throws IOException {
         super(node, transportFactory);
 
-        init(0);
+        if (transportFactory instanceof OtpGenericTransportFactory) {
+            // For alternative distribution protocols using a transport factory
+            // extending the OtpGenericTransportFactory abstract class, the
+            // local node is used as the identifier for incoming connections.
+            init();
+        } else {
+            init(0);
+        }
     }
 
     /**
@@ -133,8 +148,8 @@ public class OtpNode extends OtpLocalNode {
      *            the name of this node.
      *
      * @param cookie
-     *            the authorization cookie that will be used by this node when it
-     *            communicates with other nodes.
+     *            the authorization cookie that will be used by this node when
+     *            it communicates with other nodes.
      *
      * @exception IOException
      *                if communication could not be initialized.
@@ -151,8 +166,8 @@ public class OtpNode extends OtpLocalNode {
      *            the name of this node.
      *
      * @param cookie
-     *            the authorization cookie that will be used by this node when it
-     *            communicates with other nodes.
+     *            the authorization cookie that will be used by this node when
+     *            it communicates with other nodes.
      *
      * @param transportFactory
      *            the transport factory to use when creating connections.
@@ -163,7 +178,16 @@ public class OtpNode extends OtpLocalNode {
      */
     public OtpNode(final String node, final String cookie,
             final OtpTransportFactory transportFactory) throws IOException {
-        this(node, cookie, 0, transportFactory);
+        super(node, cookie, transportFactory);
+
+        if (transportFactory instanceof OtpGenericTransportFactory) {
+            // For alternative distribution protocols using a transport factory
+            // extending the OtpGenericTransportFactory abstract class, the
+            // local node is used as the identifier for incoming connections.
+            init();
+        } else {
+            init(0);
+        }
     }
 
     /**
@@ -173,12 +197,12 @@ public class OtpNode extends OtpLocalNode {
      *            the name of this node.
      *
      * @param cookie
-     *            the authorization cookie that will be used by this node when it
-     *            communicates with other nodes.
+     *            the authorization cookie that will be used by this node when
+     *            it communicates with other nodes.
      *
      * @param port
-     *            the port number you wish to use for incoming connections. Specifying 0
-     *            lets the system choose an available port.
+     *            the port number you wish to use for incoming connections.
+     *            Specifying 0 lets the system choose an available port.
      *
      * @exception IOException
      *                if communication could not be initialized.
@@ -198,12 +222,12 @@ public class OtpNode extends OtpLocalNode {
      *            the name of this node.
      *
      * @param cookie
-     *            the authorization cookie that will be used by this node when it
-     *            communicates with other nodes.
+     *            the authorization cookie that will be used by this node when
+     *            it communicates with other nodes.
      *
      * @param port
-     *            the port number you wish to use for incoming connections. Specifying 0
-     *            lets the system choose an available port.
+     *            the port number you wish to use for incoming connections.
+     *            Specifying 0 lets the system choose an available port.
      *
      * @param transportFactory
      *            the transport factory to use when creating connections.
@@ -219,18 +243,37 @@ public class OtpNode extends OtpLocalNode {
         init(port);
     }
 
+    /*
+     * Initialize a node instance with the port number to use for incoming
+     * connections. Specifying 0 lets the system choose an available port.
+     */
     private synchronized void init(final int aport) throws IOException {
         if (!initDone) {
-            connections = new Hashtable<>(17, (float) 0.95);
+            connections = new Hashtable<String, OtpCookedConnection>(17,
+                    (float) 0.95);
             mboxes = new Mailboxes();
             acceptor = new Acceptor(aport);
             initDone = true;
         }
     }
 
+    /*
+     * Initialize a node instance using an alternative distribution protocol
+     * with the local node used as the identifier for incoming connections.
+     */
+    private synchronized void init() throws IOException {
+        if (!initDone) {
+            connections = new Hashtable<String, OtpCookedConnection>(17,
+                    (float) 0.95);
+            mboxes = new Mailboxes();
+            acceptor = new Acceptor(this);
+            initDone = true;
+        }
+    }
+
     /**
-     * Close the node. Unpublish the node from Epmd (preventing new connections) and close
-     * all existing connections.
+     * Close the node. Unpublish the node from Epmd (preventing new connections)
+     * and close all existing connections.
      */
     public synchronized void close() {
         acceptor.quit();
@@ -254,9 +297,10 @@ public class OtpNode extends OtpLocalNode {
     }
 
     /**
-     * Create an unnamed {@link OtpMbox mailbox} that can be used to send and receive
-     * messages with other, similar mailboxes and with Erlang processes. Messages can be
-     * sent to this mailbox by using its associated {@link OtpMbox#self() pid}.
+     * Create an unnamed {@link OtpMbox mailbox} that can be used to send and
+     * receive messages with other, similar mailboxes and with Erlang processes.
+     * Messages can be sent to this mailbox by using its associated
+     * {@link OtpMbox#self() pid}.
      *
      * @return a mailbox.
      */
@@ -271,15 +315,16 @@ public class OtpNode extends OtpLocalNode {
      *            the mailbox to close.
      *
      *            <p>
-     *            After this operation, the mailbox will no longer be able to receive
-     *            messages. Any delivered but as yet unretrieved messages can still be
-     *            retrieved however.
+     *            After this operation, the mailbox will no longer be able to
+     *            receive messages. Any delivered but as yet unretrieved
+     *            messages can still be retrieved however.
      *            </p>
      *
      *            <p>
-     *            If there are links from the mailbox to other {@link OtpErlangPid pids},
-     *            they will be broken when this method is called and exit signals with
-     *            reason 'normal' will be sent.
+     *            If there are links from the mailbox to other
+     *            {@link OtpErlangPid pids}, they will be broken when this
+     *            method is called and exit signals with reason 'normal' will be
+     *            sent.
      *            </p>
      *
      */
@@ -296,15 +341,16 @@ public class OtpNode extends OtpLocalNode {
      *            an Erlang term describing the reason for the termination.
      *
      *            <p>
-     *            After this operation, the mailbox will no longer be able to receive
-     *            messages. Any delivered but as yet unretrieved messages can still be
-     *            retrieved however.
+     *            After this operation, the mailbox will no longer be able to
+     *            receive messages. Any delivered but as yet unretrieved
+     *            messages can still be retrieved however.
      *            </p>
      *
      *            <p>
-     *            If there are links from the mailbox to other {@link OtpErlangPid pids},
-     *            they will be broken when this method is called and exit signals with the
-     *            given reason will be sent.
+     *            If there are links from the mailbox to other
+     *            {@link OtpErlangPid pids}, they will be broken when this
+     *            method is called and exit signals with the given reason will
+     *            be sent.
      *            </p>
      *
      */
@@ -317,13 +363,14 @@ public class OtpNode extends OtpLocalNode {
     }
 
     /**
-     * Create an named mailbox that can be used to send and receive messages with other,
-     * similar mailboxes and with Erlang processes. Messages can be sent to this mailbox
-     * by using its registered name or the associated {@link OtpMbox#self() pid}.
+     * Create an named mailbox that can be used to send and receive messages
+     * with other, similar mailboxes and with Erlang processes. Messages can be
+     * sent to this mailbox by using its registered name or the associated
+     * {@link OtpMbox#self() pid}.
      *
      * @param name
-     *            a name to register for this mailbox. The name must be unique within this
-     *            OtpNode.
+     *            a name to register for this mailbox. The name must be unique
+     *            within this OtpNode.
      *
      * @return a mailbox, or null if the name was already in use.
      *
@@ -334,15 +381,16 @@ public class OtpNode extends OtpLocalNode {
 
     /**
      * <p>
-     * Register or remove a name for the given mailbox. Registering a name for a mailbox
-     * enables others to send messages without knowing the {@link OtpErlangPid pid} of the
-     * mailbox. A mailbox can have at most one name; if the mailbox already had a name,
-     * calling this method will supercede that name.
+     * Register or remove a name for the given mailbox. Registering a name for a
+     * mailbox enables others to send messages without knowing the
+     * {@link OtpErlangPid pid} of the mailbox. A mailbox can have at most one
+     * name; if the mailbox already had a name, calling this method will
+     * supersede that name.
      * </p>
      *
      * @param name
-     *            the name to register for the mailbox. Specify null to unregister the
-     *            existing name from this mailbox.
+     *            the name to register for the mailbox. Specify null to
+     *            unregister the existing name from this mailbox.
      *
      * @param mbox
      *            the mailbox to associate with the name.
@@ -356,7 +404,8 @@ public class OtpNode extends OtpLocalNode {
     /**
      * Get a list of all known registered names on this node.
      *
-     * @return an array of Strings, containins all known registered names on this node.
+     * @return an array of Strings, containins all known registered names on
+     *         this node.
      */
 
     public String[] getNames() {
@@ -364,11 +413,11 @@ public class OtpNode extends OtpLocalNode {
     }
 
     /**
-     * Determine the {@link OtpErlangPid pid} corresponding to a registered name on this
-     * node.
+     * Determine the {@link OtpErlangPid pid} corresponding to a registered name
+     * on this node.
      *
-     * @return the {@link OtpErlangPid pid} corresponding to the registered name, or null
-     *         if the name is not known on this node.
+     * @return the {@link OtpErlangPid pid} corresponding to the registered
+     *         name, or null if the name is not known on this node.
      */
     public OtpErlangPid whereis(final String name) {
         final OtpMbox m = mboxes.get(name);
@@ -379,13 +428,13 @@ public class OtpNode extends OtpLocalNode {
     }
 
     /**
-     * Register interest in certain system events. The {@link OtpNodeStatus OtpNodeStatus}
-     * handler object contains callback methods, that will be called when certain events
-     * occur.
+     * Register interest in certain system events. The {@link OtpNodeStatus
+     * OtpNodeStatus} handler object contains callback methods, that will be
+     * called when certain events occur.
      *
      * @param ahandler
-     *            the callback object to register. To clear the handler, specify null as
-     *            the handler to use.
+     *            the callback object to register. To clear the handler, specify
+     *            null as the handler to use.
      *
      */
     public synchronized void registerStatusHandler(final OtpNodeStatus ahandler) {
@@ -394,16 +443,17 @@ public class OtpNode extends OtpLocalNode {
 
     /**
      * <p>
-     * Determine if another node is alive. This method has the side effect of setting up a
-     * connection to the remote node (if possible). Only a single outgoing message is
-     * sent; the timeout is how long to wait for a response.
+     * Determine if another node is alive. This method has the side effect of
+     * setting up a connection to the remote node (if possible). Only a single
+     * outgoing message is sent; the timeout is how long to wait for a response.
      * </p>
      *
      * <p>
-     * Only a single attempt is made to connect to the remote node, so for example it is
-     * not possible to specify an extremely long timeout and expect to be notified when
-     * the node eventually comes up. If you wish to wait for a remote node to be started,
-     * the following construction may be useful:
+     * Only a single attempt is made to connect to the remote node, so for
+     * example it is not possible to specify an extremely long timeout and
+     * expect to be notified when the node eventually comes up. If you wish to
+     * wait for a remote node to be started, the following construction may be
+     * useful:
      * </p>
      *
      * <pre>
@@ -416,10 +466,11 @@ public class OtpNode extends OtpLocalNode {
      *            the name of the node to ping.
      *
      * @param timeout
-     *            the time, in milliseconds, to wait for response before returning false.
+     *            the time, in milliseconds, to wait for response before
+     *            returning false.
      *
-     * @return true if the node was alive and the correct ping response was returned.
-     *         false if the correct response was not returned on time.
+     * @return true if the node was alive and the correct ping response was
+     *         returned. false if the correct response was not returned on time.
      */
     /*
      * internal info about the message formats...
@@ -432,8 +483,8 @@ public class OtpNode extends OtpLocalNode {
     public boolean ping(final String anode, final long timeout) {
         if (anode.equals(node)) {
             return true;
-        } else if (anode.indexOf('@', 0) < 0
-                && anode.equals(node.substring(0, node.indexOf('@', 0)))) {
+        } else if (anode.indexOf('@') < 0
+                && anode.equals(node.substring(0, node.indexOf('@')))) {
             return true;
         }
 
@@ -474,7 +525,8 @@ public class OtpNode extends OtpLocalNode {
     }
 
     /*
-     * this method simulates net_kernel only for the purpose of replying to pings.
+     * this method simulates net_kernel only for the purpose of replying to
+     * pings.
      */
     private boolean netKernel(final OtpMsg m) {
         OtpMbox mbox = null;
@@ -501,8 +553,8 @@ public class OtpNode extends OtpLocalNode {
     }
 
     /*
-     * OtpCookedConnection delivers messages here return true if message was delivered
-     * successfully, or false otherwise.
+     * OtpCookedConnection delivers messages here return true if message was
+     * delivered successfully, or false otherwise.
      */
     boolean deliver(final OtpMsg m) {
         OtpMbox mbox = null;
@@ -512,7 +564,7 @@ public class OtpNode extends OtpLocalNode {
 
             if (t == OtpMsg.regSendTag) {
                 final String name = m.getRecipientName();
-                /* special case for netKernel requests */
+                // special case for netKernel requests
                 if (name.equals("net_kernel")) {
                     return netKernel(m);
                 }
@@ -533,8 +585,8 @@ public class OtpNode extends OtpLocalNode {
     }
 
     /*
-     * OtpCookedConnection delivers errors here, we send them on to the handler specified
-     * by the application
+     * OtpCookedConnection delivers errors here, we send them on to the handler
+     * specified by the application
      */
     void deliverError(final OtpCookedConnection conn, final Exception e) {
         removeConnection(conn);
@@ -554,7 +606,10 @@ public class OtpNode extends OtpLocalNode {
 
             if (conn == null) {
                 // in case node had no '@' add localhost info and try again
-                peer = new OtpPeer(anode);
+                peer = new OtpPeer(anode,
+                                   // Pass the transport factory to use
+                                   // when creating connections
+                                   transportFactory);
                 conn = connections.get(peer.node());
 
                 if (conn == null) {
@@ -563,7 +618,7 @@ public class OtpNode extends OtpLocalNode {
                         conn.setFlags(connFlags);
                         addConnection(conn);
                     } catch (final Exception e) {
-                        /* false = outgoing */
+                        // false = outgoing
                         connAttempt(peer.node(), false, e);
                     }
                 }
@@ -586,8 +641,8 @@ public class OtpNode extends OtpLocalNode {
     }
 
     /* use these wrappers to call handler functions */
-    private synchronized void remoteStatus(final String anode, final boolean up,
-            final Object info) {
+    private synchronized void remoteStatus(final String anode,
+            final boolean up, final Object info) {
         if (handler == null) {
             return;
         }
@@ -620,7 +675,8 @@ public class OtpNode extends OtpLocalNode {
     }
 
     /*
-     * this class used to wrap the mailbox hashtables so we can use weak references
+     * this class used to wrap the mailbox hashtables so we can use weak
+     * references
      */
     public class Mailboxes {
         // mbox pids here
@@ -629,8 +685,10 @@ public class OtpNode extends OtpLocalNode {
         private Hashtable<String, WeakReference<OtpMbox>> byName = null;
 
         public Mailboxes() {
-            byPid = new Hashtable<>(17, (float) 0.95);
-            byName = new Hashtable<>(17, (float) 0.95);
+            byPid = new Hashtable<OtpErlangPid, WeakReference<OtpMbox>>(17,
+                    (float) 0.95);
+            byName = new Hashtable<String, WeakReference<OtpMbox>>(17,
+                    (float) 0.95);
         }
 
         public OtpMbox create(final String name) {
@@ -642,8 +700,8 @@ public class OtpNode extends OtpLocalNode {
                 }
                 final OtpErlangPid pid = createPid();
                 m = new OtpMbox(OtpNode.this, pid, name);
-                byPid.put(pid, new WeakReference<>(m));
-                byName.put(name, new WeakReference<>(m));
+                byPid.put(pid, new WeakReference<OtpMbox>(m));
+                byName.put(name, new WeakReference<OtpMbox>(m));
             }
             return m;
         }
@@ -651,7 +709,7 @@ public class OtpNode extends OtpLocalNode {
         public OtpMbox create() {
             final OtpErlangPid pid = createPid();
             final OtpMbox m = new OtpMbox(OtpNode.this, pid);
-            byPid.put(pid, new WeakReference<>(m));
+            byPid.put(pid, new WeakReference<OtpMbox>(m));
             return m;
         }
 
@@ -687,7 +745,7 @@ public class OtpNode extends OtpLocalNode {
                     if (get(name) != null) {
                         return false;
                     }
-                    byName.put(name, new WeakReference<>(mbox));
+                    byName.put(name, new WeakReference<OtpMbox>(mbox));
                     mbox.name = name;
                 }
             }
@@ -695,8 +753,9 @@ public class OtpNode extends OtpLocalNode {
         }
 
         /*
-         * look up a mailbox based on its name. If the mailbox has gone out of scope we
-         * also remove the reference from the hashtable so we don't find it again.
+         * look up a mailbox based on its name. If the mailbox has gone out of
+         * scope we also remove the reference from the hashtable so we don't
+         * find it again.
          */
         public OtpMbox get(final String name) {
             final WeakReference<OtpMbox> wr = byName.get(name);
@@ -713,8 +772,9 @@ public class OtpNode extends OtpLocalNode {
         }
 
         /*
-         * look up a mailbox based on its pid. If the mailbox has gone out of scope we
-         * also remove the reference from the hashtable so we don't find it again.
+         * look up a mailbox based on its pid. If the mailbox has gone out of
+         * scope we also remove the reference from the hashtable so we don't
+         * find it again.
          */
         public OtpMbox get(final OtpErlangPid pid) {
             final WeakReference<OtpMbox> wr = byPid.get(pid);
@@ -753,7 +813,28 @@ public class OtpNode extends OtpLocalNode {
 
             setDaemon(true);
             setName("acceptor");
+            // Publish the node through Epmd
             publishPort();
+            start();
+        }
+
+        /*
+         * Constructor for alternative distribution protocols using a transport
+         * factory extending the OtpGenericTransportFactory abstract class.
+         *
+         * The notion of socket port is not used with such protocols so the
+         * node is not published via Epmd.
+         */
+        Acceptor(final OtpLocalNode node) throws IOException {
+            // Set acceptorPort arbitrarily to 0, it won't be used later on.
+            acceptorPort = 0;
+
+            // The local node is passed as the identifier to use for incoming
+            // connections.
+            sock = createServerTransport(node);
+
+            setDaemon(true);
+            setName("acceptor");
             start();
         }
 
@@ -766,10 +847,16 @@ public class OtpNode extends OtpLocalNode {
         }
 
         private void unPublishPort() {
-            // unregister with epmd
+            // The notion of socket port is not used with such an alternative
+            // distribution protocol so the node was not registered with Epmd.
+            if (transportFactory instanceof OtpGenericTransportFactory) {
+                return;
+            }
+
+            // Unregister the node from Epmd
             OtpEpmd.unPublishPort(OtpNode.this);
 
-            // close the local descriptor (if we have one)
+            // Close the local descriptor (if we have one)
             closeSock(epmd);
             epmd = null;
         }
@@ -810,8 +897,7 @@ public class OtpNode extends OtpLocalNode {
 
             localStatus(node, true, null);
 
-            accept_loop:
-            while (!done) {
+            accept_loop: while (!done) {
                 conn = null;
 
                 try {
@@ -856,7 +942,7 @@ public class OtpNode extends OtpLocalNode {
                 }
             } // while
 
-            // if we have exited loop we must do this too
+            // If we have exited loop we must do this too
             unPublishPort();
         }
     }

--- a/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpNodeStatus.java
+++ b/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpNodeStatus.java
@@ -3,15 +3,17 @@
  *
  * Copyright Ericsson AB 2000-2016. All Rights Reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
- * file except in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under
- * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * %CopyrightEnd%
  */
@@ -19,15 +21,16 @@ package com.ericsson.otp.erlang;
 
 /**
  * <p>
- * Provides a callback mechanism for receiving status change information about other nodes
- * in the system. Register an instance of this class (or a subclass) with your
- * {@link OtpNode OtpNode} when you wish to be notified about such status changes and
- * other similar events.
+ * Provides a callback mechanism for receiving status change information about
+ * other nodes in the system. Register an instance of this class (or a subclass)
+ * with your {@link OtpNode OtpNode} when you wish to be notified about such
+ * status changes and other similar events.
  * </p>
  *
  * <p>
- * This class provides default handers that ignore all events. Applications are expected
- * to extend this class in order to act on events that are deemed interesting.
+ * This class provides default handers that ignore all events. Applications are
+ * expected to extend this class in order to act on events that are deemed
+ * interesting.
  * </p>
  *
  * <p>
@@ -48,11 +51,13 @@ public class OtpNodeStatus {
      *            true if the node has come up, false if it has gone down.
      *
      * @param info
-     *            additional info that may be available, for example an exception that was
-     *            raised causing the event in question (may be null).
+     *            additional info that may be available, for example an
+     *            exception that was raised causing the event in question (may
+     *            be null).
      *
      */
-    public void remoteStatus(final String node, final boolean up, final Object info) {
+    public void remoteStatus(final String node, final boolean up,
+            final Object info) {
     }
 
     /**
@@ -65,10 +70,12 @@ public class OtpNodeStatus {
      *            true if the node has come up, false if it has gone down.
      *
      * @param info
-     *            additional info that may be available, for example an exception that was
-     *            raised causing the event in question (may be null).
+     *            additional info that may be available, for example an
+     *            exception that was raised causing the event in question (may
+     *            be null).
      */
-    public void localStatus(final String node, final boolean up, final Object info) {
+    public void localStatus(final String node, final boolean up,
+            final Object info) {
     }
 
     /**
@@ -78,12 +85,13 @@ public class OtpNodeStatus {
      *            The name of the remote node
      *
      * @param incoming
-     *            The direction of the connection attempt, i.e. true for incoming, false
-     *            for outgoing.
+     *            The direction of the connection attempt, i.e. true for
+     *            incoming, false for outgoing.
      *
      * @param info
-     *            additional info that may be available, for example an exception that was
-     *            raised causing the event in question (may be null).
+     *            additional info that may be available, for example an
+     *            exception that was raised causing the event in question (may
+     *            be null).
      */
     public void connAttempt(final String node, final boolean incoming,
             final Object info) {

--- a/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpOutputStream.java
+++ b/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpOutputStream.java
@@ -1,17 +1,19 @@
 /*
  * %CopyrightBegin%
  *
- * Copyright Ericsson AB 2000-2017. All Rights Reserved.
+ * Copyright Ericsson AB 2000-2022. All Rights Reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
- * file except in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under
- * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * %CopyrightEnd%
  */
@@ -28,12 +30,12 @@ import java.text.DecimalFormat;
 import java.util.zip.Deflater;
 
 /**
- * Provides a stream for encoding Erlang terms to external format, for transmission or
- * storage.
+ * Provides a stream for encoding Erlang terms to external format, for
+ * transmission or storage.
  *
  * <p>
- * Note that this class is not synchronized, if you need synchronization you must provide
- * it yourself.
+ * Note that this class is not synchronized, if you need synchronization you
+ * must provide it yourself.
  *
  */
 public class OtpOutputStream extends ByteArrayOutputStream {
@@ -41,8 +43,8 @@ public class OtpOutputStream extends ByteArrayOutputStream {
     public static final int defaultInitialSize = 2048;
 
     /**
-     * The default increment used when growing the stream (increment at least this much).
-     * *
+     * The default increment used when growing the stream (increment at least
+     * this much). *
      */
     public static final int defaultIncrement = 2048;
 
@@ -80,12 +82,13 @@ public class OtpOutputStream extends ByteArrayOutputStream {
 
     // package scope
     /*
-     * Get the contents of the output stream as an input stream instead. This is used
-     * internally in {@link OtpCconnection} for tracing outgoing packages.
+     * Get the contents of the output stream as an input stream instead. This is
+     * used internally in {@link OtpCconnection} for tracing outgoing packages.
      *
-     * @param offset where in the output stream to read data from when creating the input
-     * stream. The offset is necessary because header contents start 5 bytes into the
-     * header buffer, whereas payload contents start at the beginning
+     * @param offset where in the output stream to read data from when creating
+     * the input stream. The offset is necessary because header contents start 5
+     * bytes into the header buffer, whereas payload contents start at the
+     * beginning
      *
      * @return an input stream containing the same raw data.
      */
@@ -103,9 +106,9 @@ public class OtpOutputStream extends ByteArrayOutputStream {
     }
 
     /**
-     * Trims the capacity of this <code>OtpOutputStream</code> instance to be the buffer's
-     * current size. An application can use this operation to minimize the storage of an
-     * <code>OtpOutputStream</code> instance.
+     * Trims the capacity of this <code>OtpOutputStream</code> instance to be the
+     * buffer's current size. An application can use this operation to minimize
+     * the storage of an <code>OtpOutputStream</code> instance.
      */
     public void trimToSize() {
         resize(super.count);
@@ -122,16 +125,17 @@ public class OtpOutputStream extends ByteArrayOutputStream {
     }
 
     /**
-     * Increases the capacity of this <code>OtpOutputStream</code> instance, if necessary,
-     * to ensure that it can hold at least the number of elements specified by the minimum
-     * capacity argument.
+     * Increases the capacity of this <code>OtpOutputStream</code> instance, if
+     * necessary, to ensure that it can hold at least the number of elements
+     * specified by the minimum capacity argument.
      *
      * @param minCapacity
      *            the desired minimum capacity
      */
     public void ensureCapacity(final int minCapacity) {
         if (minCapacity > fixedSize) {
-            throw new IllegalArgumentException("Trying to increase fixed-size buffer");
+            throw new IllegalArgumentException(
+                    "Trying to increase fixed-size buffer");
         }
         final int oldCapacity = super.buf.length;
         if (minCapacity > oldCapacity) {
@@ -164,7 +168,7 @@ public class OtpOutputStream extends ByteArrayOutputStream {
 
     /*
      * (non-Javadoc)
-     *
+     * 
      * @see java.io.ByteArrayOutputStream#write(byte[])
      */
     @Override
@@ -175,7 +179,7 @@ public class OtpOutputStream extends ByteArrayOutputStream {
 
     /*
      * (non-Javadoc)
-     *
+     * 
      * @see java.io.ByteArrayOutputStream#write(int)
      */
     @Override
@@ -187,7 +191,7 @@ public class OtpOutputStream extends ByteArrayOutputStream {
 
     /*
      * (non-Javadoc)
-     *
+     * 
      * @see java.io.ByteArrayOutputStream#write(byte[], int, int)
      */
     @Override
@@ -201,11 +205,11 @@ public class OtpOutputStream extends ByteArrayOutputStream {
     }
 
     @Override
-    public synchronized void writeTo(final OutputStream out) throws IOException {
+    public synchronized void writeTo(OutputStream out) throws IOException {
         super.writeTo(out);
     }
 
-    public synchronized void writeToAndFlush(final OutputStream out) throws IOException {
+    public synchronized void writeToAndFlush(OutputStream out) throws IOException {
         super.writeTo(out);
         out.flush();
     }
@@ -233,8 +237,9 @@ public class OtpOutputStream extends ByteArrayOutputStream {
     }
 
     /**
-     * Get the current capacity of the stream. As bytes are added the capacity of the
-     * stream is increased automatically, however this method returns the current size.
+     * Get the current capacity of the stream. As bytes are added the capacity
+     * of the stream is increased automatically, however this method returns the
+     * current size.
      *
      * @return the size of the internal buffer used by the stream.
      */
@@ -281,7 +286,8 @@ public class OtpOutputStream extends ByteArrayOutputStream {
     }
 
     /**
-     * Write the low eight (all) bytes of a value to the stream in big endian order.
+     * Write the low eight (all) bytes of a value to the stream in big endian
+     * order.
      *
      * @param n
      *            the value to use.
@@ -338,7 +344,8 @@ public class OtpOutputStream extends ByteArrayOutputStream {
     }
 
     /**
-     * Write the low eight bytes of a value to the stream in little endian order.
+     * Write the low eight bytes of a value to the stream in little endian
+     * order.
      *
      * @param n
      *            the value to use.
@@ -355,13 +362,13 @@ public class OtpOutputStream extends ByteArrayOutputStream {
     }
 
     /**
-     * Write the low four bytes of a value to the stream in bif endian order, at the
-     * specified position. If the position specified is beyond the end of the stream, this
-     * method will have no effect.
+     * Write the low four bytes of a value to the stream in bif endian order, at
+     * the specified position. If the position specified is beyond the end of
+     * the stream, this method will have no effect.
      *
-     * Normally this method should be used in conjunction with {@link #size() size()},
-     * when is is necessary to insert data into the stream before it is known what the
-     * actual value should be. For example:
+     * Normally this method should be used in conjunction with {@link #size()
+     * size()}, when is is necessary to insert data into the stream before it is
+     * known what the actual value should be. For example:
      *
      * <pre>
      * int pos = s.size();
@@ -401,8 +408,8 @@ public class OtpOutputStream extends ByteArrayOutputStream {
             enc_atom = atom;
         } else {
             /*
-             * Throwing an exception would be better I think, but truncation seems to be
-             * the way it has been done in other parts of OTP...
+             * Throwing an exception would be better I think, but truncation
+             * seems to be the way it has been done in other parts of OTP...
              */
             enc_atom = new String(OtpErlangString.stringToCodePoints(atom), 0,
                     OtpExternal.maxAtomLength);
@@ -421,9 +428,10 @@ public class OtpOutputStream extends ByteArrayOutputStream {
             writeN(bytes);
         } catch (final java.io.UnsupportedEncodingException e) {
             /*
-             * Sigh, why didn't the API designer add an OtpErlangEncodeException to these
-             * encoding functions?!? Instead of changing the API we write an invalid atom
-             * and let it fail for whoever trying to decode this... Sigh, again...
+             * Sigh, why didn't the API designer add an OtpErlangEncodeException
+             * to these encoding functions?!? Instead of changing the API we
+             * write an invalid atom and let it fail for whoever trying to
+             * decode this... Sigh, again...
              */
             write1(OtpExternal.smallAtomUtf8Tag);
             write1(2);
@@ -473,8 +481,8 @@ public class OtpOutputStream extends ByteArrayOutputStream {
     }
 
     /**
-     * Write a single byte to the stream as an Erlang integer. The byte is really an IDL
-     * 'octet', that is, unsigned.
+     * Write a single byte to the stream as an Erlang integer. The byte is
+     * really an IDL 'octet', that is, unsigned.
      *
      * @param b
      *            the byte to use.
@@ -484,9 +492,9 @@ public class OtpOutputStream extends ByteArrayOutputStream {
     }
 
     /**
-     * Write a character to the stream as an Erlang integer. The character may be a 16 bit
-     * character, kind of IDL 'wchar'. It is up to the Erlang side to take care of souch,
-     * if they should be used.
+     * Write a character to the stream as an Erlang integer. The character may
+     * be a 16 bit character, kind of IDL 'wchar'. It is up to the Erlang side
+     * to take care of souch, if they should be used.
      *
      * @param c
      *            the character to use.
@@ -550,31 +558,33 @@ public class OtpOutputStream extends ByteArrayOutputStream {
     void write_long(final long v, final boolean unsigned) {
         /*
          * If v<0 and unsigned==true the value
-         * java.lang.Long.MAX_VALUE-java.lang.Long.MIN_VALUE+1+v is written, i.e v is
-         * regarded as unsigned two's complement.
+         * java.lang.Long.MAX_VALUE-java.lang.Long.MIN_VALUE+1+v is written, i.e
+         * v is regarded as unsigned two's complement.
          */
         if ((v & 0xffL) == v) {
             // will fit in one byte
             write1(OtpExternal.smallIntTag);
             write1(v);
-        } else // note that v != 0L
-        if (v < 0 && unsigned || v < OtpExternal.erlMin || v > OtpExternal.erlMax) {
-            // some kind of bignum
-            final long abs = unsigned ? v : v < 0 ? -v : v;
-            final int sign = unsigned ? 0 : v < 0 ? 1 : 0;
-            int n;
-            long mask;
-            for (mask = 0xFFFFffffL, n = 4; (abs & mask) != abs; n++, mask = mask << 8
-                    | 0xffL) {
-                // count nonzero bytes
-            }
-            write1(OtpExternal.smallBigTag);
-            write1(n); // length
-            write1(sign); // sign
-            writeLE(abs, n); // value. obs! little endian
         } else {
-            write1(OtpExternal.intTag);
-            write4BE(v);
+            // note that v != 0L
+            if (v < 0 && unsigned || v < OtpExternal.erlMin
+                    || v > OtpExternal.erlMax) {
+                // some kind of bignum
+                final long abs = unsigned ? v : v < 0 ? -v : v;
+                final int sign = unsigned ? 0 : v < 0 ? 1 : 0;
+                int n;
+                long mask;
+                for (mask = 0xFFFFffffL, n = 4; (abs & mask) != abs; n++, mask = mask << 8 | 0xffL) {
+                    // count nonzero bytes
+                }
+                write1(OtpExternal.smallBigTag);
+                write1(n); // length
+                write1(sign); // sign
+                writeLE(abs, n); // value. obs! little endian
+            } else {
+                write1(OtpExternal.intTag);
+                write4BE(v);
+            }
         }
     }
 
@@ -589,8 +599,8 @@ public class OtpOutputStream extends ByteArrayOutputStream {
     }
 
     /**
-     * Write a positive long to the stream. The long is interpreted as a two's complement
-     * unsigned long even if it is negative.
+     * Write a positive long to the stream. The long is interpreted as a two's
+     * complement unsigned long even if it is negative.
      *
      * @param ul
      *            the long to use.
@@ -610,8 +620,8 @@ public class OtpOutputStream extends ByteArrayOutputStream {
     }
 
     /**
-     * Write a positive integer to the stream. The integer is interpreted as a two's
-     * complement unsigned integer even if it is negative.
+     * Write a positive integer to the stream. The integer is interpreted as a
+     * two's complement unsigned integer even if it is negative.
      *
      * @param ui
      *            the integer to use.
@@ -642,9 +652,9 @@ public class OtpOutputStream extends ByteArrayOutputStream {
     }
 
     /**
-     * Write an Erlang list header to the stream. After calling this method, you must
-     * write 'arity' elements to the stream followed by nil, or it will not be possible to
-     * decode it later.
+     * Write an Erlang list header to the stream. After calling this method, you
+     * must write 'arity' elements to the stream followed by nil, or it will not
+     * be possible to decode it later.
      *
      * @param arity
      *            the number of elements in the list.
@@ -666,8 +676,9 @@ public class OtpOutputStream extends ByteArrayOutputStream {
     }
 
     /**
-     * Write an Erlang tuple header to the stream. After calling this method, you must
-     * write 'arity' elements to the stream or it will not be possible to decode it later.
+     * Write an Erlang tuple header to the stream. After calling this method,
+     * you must write 'arity' elements to the stream or it will not be possible
+     * to decode it later.
      *
      * @param arity
      *            the number of elements in the tuple.
@@ -689,22 +700,22 @@ public class OtpOutputStream extends ByteArrayOutputStream {
      *            the nodename.
      *
      * @param id
-     *            an arbitrary number. Only the low order 15 bits will be used.
+     *            an arbitrary number.
      *
      * @param serial
-     *            another arbitrary number. Only the low order 13 bits will be used.
+     *            another arbitrary number.
      *
      * @param creation
-     *            yet another arbitrary number. Only the low order 2 bits will be used.
+     *            node incarnation number.
      *
      */
     public void write_pid(final String node, final int id, final int serial,
             final int creation) {
-        write1(OtpExternal.newPidTag);
-        write_atom(node);
-        write4BE(id & 0x7fff); // 15 bits
-        write4BE(serial & 0x1fff); // 13 bits
-        write1(creation & 0x3); // 2 bits
+	write1(OtpExternal.newPidTag);
+	write_atom(node);
+	write4BE(id);
+	write4BE(serial);
+	write4BE(creation);
     }
 
     /**
@@ -713,13 +724,14 @@ public class OtpOutputStream extends ByteArrayOutputStream {
      * @param pid
      *            the pid
      */
-    public void write_pid(final OtpErlangPid pid) {
-        write1(OtpExternal.newPidTag);
-        write_atom(pid.node());
-        write4BE(pid.id());
-        write4BE(pid.serial());
+    public void write_pid(OtpErlangPid pid) {
+	write1(OtpExternal.newPidTag);
+	write_atom(pid.node());
+	write4BE(pid.id());
+	write4BE(pid.serial());
         write4BE(pid.creation());
     }
+
 
     /**
      * Write an Erlang port to the stream.
@@ -731,7 +743,8 @@ public class OtpOutputStream extends ByteArrayOutputStream {
      *            an arbitrary number. Only the low order 28 bits will be used.
      *
      * @param creation
-     *            another arbitrary number. Only the low order 2 bits will be used.
+     *            another arbitrary number. Only the low order 2 bits will
+     *            be used.
      */
     public void write_port(final String node, final long id, final int creation) {
         if ((id & ~0xfffffffL) != 0) { /* > 28 bits */
@@ -739,7 +752,8 @@ public class OtpOutputStream extends ByteArrayOutputStream {
             write_atom(node);
             write8BE(id);
             write4BE(creation);
-        } else {
+        }
+        else {
             write1(OtpExternal.newPortTag);
             write_atom(node);
             write4BE(id);
@@ -753,13 +767,14 @@ public class OtpOutputStream extends ByteArrayOutputStream {
      * @param port
      *            the port.
      */
-    public void write_port(final OtpErlangPort port) {
+    public void write_port(OtpErlangPort port) {
         if ((port.id() & ~0xfffffffL) != 0) { /* > 28 bits */
             write1(OtpExternal.v4PortTag);
             write_atom(port.node());
             write8BE(port.id());
             write4BE(port.creation());
-        } else {
+        }
+        else {
             write1(OtpExternal.newPortTag);
             write_atom(port.node());
             write4BE((int) port.id());
@@ -781,13 +796,12 @@ public class OtpOutputStream extends ByteArrayOutputStream {
      *
      */
     public void write_ref(final String node, final int id, final int creation) {
-        /*
-         * Always encode as an extended reference; all participating parties are now
-         * expected to be able to decode extended references.
-         */
-        final int ids[] = new int[1];
-        ids[0] = id;
-        write_ref(node, ids, creation);
+	/* Always encode as an extended reference; all
+	   participating parties are now expected to be
+	   able to decode extended references. */
+	int ids[] = new int[1];
+	ids[0] = id;
+	write_ref(node, ids, creation);
     }
 
     /**
@@ -797,11 +811,11 @@ public class OtpOutputStream extends ByteArrayOutputStream {
      *            the nodename.
      *
      * @param ids
-     *            an array of arbitrary numbers. Only the low order 18 bits of the first
-     *            number will be used. At most three numbers will be read from the array.
+     *            an array of arbitrary numbers. At most three numbers
+     *            will be read from the array.
      *
      * @param creation
-     *            another arbitrary number. Only the low order 2 bits will be used.
+     *            another arbitrary number.
      *
      */
     public void write_ref(final String node, final int[] ids, final int creation) {
@@ -810,22 +824,18 @@ public class OtpOutputStream extends ByteArrayOutputStream {
             arity = 5; // max 5 words in ref
         }
 
-        write1(OtpExternal.newerRefTag);
+	write1(OtpExternal.newerRefTag);
 
-        // how many id values
-        write2BE(arity);
+	// how many id values
+	write2BE(arity);
 
-        write_atom(node);
+	write_atom(node);
 
-        write1(creation & 0x3); // 2 bits
+	write4BE(creation);
 
-        // first int gets truncated to 18 bits
-        write4BE(ids[0] & 0x3ffff);
-
-        // remaining ones are left as is
-        for (int i = 1; i < arity; i++) {
-            write4BE(ids[i]);
-        }
+	for (int i = 0; i < arity; i++) {
+	    write4BE(ids[i]);
+	}
     }
 
     /**
@@ -834,18 +844,18 @@ public class OtpOutputStream extends ByteArrayOutputStream {
      * @param ref
      *            the reference
      */
-    public void write_ref(final OtpErlangRef ref) {
-        final int[] ids = ref.ids();
-        final int arity = ids.length;
+    public void write_ref(OtpErlangRef ref) {
+	int[] ids = ref.ids();
+        int arity = ids.length;
 
-        write1(OtpExternal.newerRefTag);
-        write2BE(arity);
-        write_atom(ref.node());
+	write1(OtpExternal.newerRefTag);
+	write2BE(arity);
+	write_atom(ref.node());
         write4BE(ref.creation());
 
-        for (int i = 0; i < arity; i++) {
-            write4BE(ids[i]);
-        }
+	for (int i = 0; i < arity; i++) {
+	    write4BE(ids[i]);
+	}
     }
 
     /**
@@ -914,9 +924,10 @@ public class OtpOutputStream extends ByteArrayOutputStream {
         @SuppressWarnings("resource")
         final OtpOutputStream oos = new OtpOutputStream(o);
         /*
-         * similar to erts_term_to_binary() in external.c: We don't want to compress if
-         * compression actually increases the size. Since compression uses 5 extra bytes
-         * (COMPRESSED tag + size), don't compress if the original term is smaller.
+         * similar to erts_term_to_binary() in external.c: We don't want to
+         * compress if compression actually increases the size. Since
+         * compression uses 5 extra bytes (COMPRESSED tag + size), don't
+         * compress if the original term is smaller.
          */
         if (oos.size() < 5) {
             // fast path for small terms
@@ -945,19 +956,20 @@ public class OtpOutputStream extends ByteArrayOutputStream {
                 dos.close(); // note: closes this, too!
             } catch (final IllegalArgumentException e) {
                 /*
-                 * Discard further un-compressed data (if not called, there may be memory
-                 * leaks).
+                 * Discard further un-compressed data (if not called, there may
+                 * be memory leaks).
                  *
-                 * After calling java.util.zip.Deflater.end(), the deflater should not be
-                 * used anymore, not even the close() method of dos. Calling dos.close()
-                 * before def.end() is prevented since an unfinished DeflaterOutputStream
-                 * will try to deflate its unprocessed data to the (fixed) byte array
-                 * which is prevented by ensureCapacity() and would also unnecessarily
-                 * process further data that is discarded anyway.
+                 * After calling java.util.zip.Deflater.end(), the deflater
+                 * should not be used anymore, not even the close() method of
+                 * dos. Calling dos.close() before def.end() is prevented since
+                 * an unfinished DeflaterOutputStream will try to deflate its
+                 * unprocessed data to the (fixed) byte array which is prevented
+                 * by ensureCapacity() and would also unnecessarily process
+                 * further data that is discarded anyway.
                  *
-                 * Since we are re-using the byte array of this object below, we must not
-                 * call close() in e.g. a finally block either (with or without a call to
-                 * def.end()).
+                 * Since we are re-using the byte array of this object below, we
+                 * must not call close() in e.g. a finally block either (with or
+                 * without a call to def.end()).
                  */
                 def.end();
                 // could not make the value smaller than originally
@@ -993,8 +1005,8 @@ public class OtpOutputStream extends ByteArrayOutputStream {
     }
 
     public void write_fun(final OtpErlangPid pid, final String module,
-            final long old_index, final int arity, final byte[] md5, final long index,
-            final long uniq, final OtpErlangObject[] freeVars) {
+            final long old_index, final int arity, final byte[] md5,
+            final long index, final long uniq, final OtpErlangObject[] freeVars) {
         if (arity == -1) {
             write1(OtpExternal.funTag);
             write4BE(freeVars.length);

--- a/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpPeer.java
+++ b/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpPeer.java
@@ -3,15 +3,17 @@
  *
  * Copyright Ericsson AB 2000-2016. All Rights Reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
- * file except in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under
- * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * %CopyrightEnd%
  */
@@ -21,13 +23,14 @@ import java.io.IOException;
 import java.net.UnknownHostException;
 
 /**
- * Represents a remote OTP node. It acts only as a container for the nodename and other
- * node-specific information that is needed by the {@link OtpConnection} class.
+ * Represents a remote OTP node. It acts only as a container for the nodename
+ * and other node-specific information that is needed by the
+ * {@link OtpConnection} class.
  */
 public class OtpPeer extends AbstractNode {
     int distChoose = 0; /*
-                         * this is set by OtpConnection and is the highest common protocol
-                         * version we both support
+                         * this is set by OtpConnection and is the highest
+                         * common protocol version we both support
                          */
 
     OtpPeer(final OtpTransportFactory transportFactory) {
@@ -52,7 +55,8 @@ public class OtpPeer extends AbstractNode {
      * @param transportFactory
      *            custom transport factory
      */
-    public OtpPeer(final String node, final OtpTransportFactory transportFactory) {
+    public OtpPeer(final String node, final OtpTransportFactory
+            transportFactory) {
         super(node, transportFactory);
     }
 
@@ -76,8 +80,8 @@ public class OtpPeer extends AbstractNode {
      * @deprecated Use the corresponding method in {@link OtpSelf} instead.
      */
     @Deprecated
-    public OtpConnection connect(final OtpSelf self)
-            throws IOException, UnknownHostException, OtpAuthException {
+    public OtpConnection connect(final OtpSelf self) throws IOException,
+            UnknownHostException, OtpAuthException {
         return new OtpConnection(self, this);
     }
 

--- a/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpSelf.java
+++ b/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpSelf.java
@@ -1,17 +1,19 @@
 /*
  * %CopyrightBegin%
  *
- * Copyright Ericsson AB 2000-2016. All Rights Reserved.
+ * Copyright Ericsson AB 2000-2022. All Rights Reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
- * file except in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under
- * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * %CopyrightEnd%
  */
@@ -21,19 +23,19 @@ import java.io.IOException;
 import java.net.UnknownHostException;
 
 /**
- * Represents an OTP node. It is used to connect to remote nodes or accept incoming
- * connections from remote nodes.
+ * Represents an OTP node. It is used to connect to remote nodes or accept
+ * incoming connections from remote nodes.
  *
  * <p>
- * When the Java node will be connecting to a remote Erlang, Java or C node, it must first
- * identify itself as a node by creating an instance of this class, after which it may
- * connect to the remote node.
+ * When the Java node will be connecting to a remote Erlang, Java or C node, it
+ * must first identify itself as a node by creating an instance of this class,
+ * after which it may connect to the remote node.
  *
  * <p>
- * When you create an instance of this class, it will bind a socket to a port so that
- * incoming connections can be accepted. However the port number will not be made
- * available to other nodes wishing to connect until you explicitely register with the
- * port mapper daemon by calling {@link #publishPort()}.
+ * When you create an instance of this class, it will bind a socket to a port so
+ * that incoming connections can be accepted. However the port number will not
+ * be made available to other nodes wishing to connect until you explicitly
+ * register with the port mapper daemon by calling {@link #publishPort()}.
  * </p>
  *
  * <pre>
@@ -50,14 +52,15 @@ public class OtpSelf extends OtpLocalNode {
 
     /**
      * <p>
-     * Create a self node using the default cookie. The default cookie is found by reading
-     * the first line of the .erlang.cookie file in the user's home directory. The home
-     * directory is obtained from the System property "user.home".
+     * Create a self node using the default cookie. The default cookie is found
+     * by reading the first line of the .erlang.cookie file in the user's home
+     * directory. The home directory is obtained from the System property
+     * "user.home".
      * </p>
      *
      * <p>
-     * If the file does not exist, an empty string is used. This method makes no attempt
-     * to create the file.
+     * If the file does not exist, an empty string is used. This method makes no
+     * attempt to create the file.
      * </p>
      *
      * @param node
@@ -73,15 +76,15 @@ public class OtpSelf extends OtpLocalNode {
 
     /**
      * <p>
-     * Create a self node using the default cookie and custom transport factory. The
-     * default cookie is found by reading the first line of the .erlang.cookie file in the
-     * user's home directory. The home directory is obtained from the System property
-     * "user.home".
+     * Create a self node using the default cookie and custom transport factory.
+     * The default cookie is found by reading the first line of the
+     * .erlang.cookie file in the user's home directory. The home directory is
+     * obtained from the System property "user.home".
      * </p>
      *
      * <p>
-     * If the file does not exist, an empty string is used. This method makes no attempt
-     * to create the file.
+     * If the file does not exist, an empty string is used. This method makes no
+     * attempt to create the file.
      * </p>
      *
      * @param node
@@ -94,8 +97,8 @@ public class OtpSelf extends OtpLocalNode {
      *                in case of server transport failure
      *
      */
-    public OtpSelf(final String node, final OtpTransportFactory transportFactory)
-            throws IOException {
+    public OtpSelf(final String node,
+            final OtpTransportFactory transportFactory) throws IOException {
         this(node, defaultCookie, 0, transportFactory);
     }
 
@@ -106,8 +109,8 @@ public class OtpSelf extends OtpLocalNode {
      *            the name of this node.
      *
      * @param cookie
-     *            the authorization cookie that will be used by this node when it
-     *            communicates with other nodes.
+     *            the authorization cookie that will be used by this node when
+     *            it communicates with other nodes.
      *
      * @exception IOException
      *                in case of server transport failure
@@ -123,8 +126,8 @@ public class OtpSelf extends OtpLocalNode {
      *            the name of this node.
      *
      * @param cookie
-     *            the authorization cookie that will be used by this node when it
-     *            communicates with other nodes.
+     *            the authorization cookie that will be used by this node when
+     *            it communicates with other nodes.
      *
      * @param transportFactory
      *            the transport factory to use when creating connections.
@@ -144,12 +147,12 @@ public class OtpSelf extends OtpLocalNode {
      *            the name of this node.
      *
      * @param cookie
-     *            the authorization cookie that will be used by this node when it
-     *            communicates with other nodes.
+     *            the authorization cookie that will be used by this node when
+     *            it communicates with other nodes.
      *
      * @param port
-     *            the port number you wish to use for incoming connections. Specifying 0
-     *            lets the system choose an available port.
+     *            the port number you wish to use for incoming connections.
+     *            Specifying 0 lets the system choose an available port.
      *
      * @exception IOException
      *                in case of server transport failure
@@ -176,12 +179,12 @@ public class OtpSelf extends OtpLocalNode {
      *            the name of this node.
      *
      * @param cookie
-     *            the authorization cookie that will be used by this node when it
-     *            communicates with other nodes.
+     *            the authorization cookie that will be used by this node when
+     *            it communicates with other nodes.
      *
      * @param port
-     *            the port number you wish to use for incoming connections. Specifying 0
-     *            lets the system choose an available port.
+     *            the port number you wish to use for incoming connections.
+     *            Specifying 0 lets the system choose an available port.
      *
      * @param transportFactory
      *            the transport factory to use when creating connections.
@@ -193,46 +196,57 @@ public class OtpSelf extends OtpLocalNode {
             final OtpTransportFactory transportFactory) throws IOException {
         super(node, cookie, transportFactory);
 
-        sock = createServerTransport(port);
+        if (transportFactory instanceof OtpGenericTransportFactory) {
+            // For alternative distribution protocols using a transport factory
+            // extending the OtpGenericTransportFactory abstract class, pass the
+            // local node as the identifier to use for incoming connections.
+            sock = createServerTransport(this);
 
-        if (port != 0) {
-            this.port = port;
         } else {
-            this.port = sock.getLocalPort();
+            sock = createServerTransport(port);
+
+            if (port != 0) {
+                this.port = port;
+            } else {
+                this.port = sock.getLocalPort();
+            }
         }
 
         pid = createPid();
     }
 
     /**
-     * Get the Erlang PID that will be used as the sender id in all "anonymous" messages
-     * sent by this node. Anonymous messages are those sent via send methods in
-     * {@link OtpConnection OtpConnection} that do not specify a sender.
+     * Get the Erlang PID that will be used as the sender id in all "anonymous"
+     * messages sent by this node. Anonymous messages are those sent via send
+     * methods in {@link OtpConnection OtpConnection} that do not specify a
+     * sender.
      *
-     * @return the Erlang PID that will be used as the sender id in all anonymous messages
-     *         sent by this node.
+     * @return the Erlang PID that will be used as the sender id in all
+     *         anonymous messages sent by this node.
      */
     public OtpErlangPid pid() {
         return pid;
     }
 
     /**
-     * Make public the information needed by remote nodes that may wish to connect to this
-     * one. This method establishes a connection to the Erlang port mapper (Epmd) and
-     * registers the server node's name and port so that remote nodes are able to connect.
+     * Make public the information needed by remote nodes that may wish to
+     * connect to this one. This method establishes a connection to the Erlang
+     * port mapper (Epmd) and registers the server node's name and port so that
+     * remote nodes are able to connect.
      *
      * <p>
-     * This method will fail if an Epmd process is not running on the localhost. See the
-     * Erlang documentation for information about starting Epmd.
+     * This method will fail if an Epmd process is not running on the localhost.
+     * See the Erlang documentation for information about starting Epmd.
      *
      * <p>
-     * Note that once this method has been called, the node is expected to be available to
-     * accept incoming connections. For that reason you should make sure that you call
-     * {@link #accept()} shortly after calling {@link #publishPort()}. When you no longer
-     * intend to accept connections you should call {@link #unPublishPort()}.
+     * Note that once this method has been called, the node is expected to be
+     * available to accept incoming connections. For that reason you should make
+     * sure that you call {@link #accept()} shortly after calling
+     * {@link #publishPort()}. When you no longer intend to accept connections
+     * you should call {@link #unPublishPort()}.
      *
-     * @return true if the operation was successful, false if the node was already
-     *         registered.
+     * @return true if the operation was successful, false if the node was
+     *         already registered.
      *
      * @exception java.io.IOException
      *                if the port mapper could not be contacted.
@@ -247,8 +261,8 @@ public class OtpSelf extends OtpLocalNode {
     }
 
     /**
-     * Unregister the server node's name and port number from the Erlang port mapper, thus
-     * preventing any new connections from remote nodes.
+     * Unregister the server node's name and port number from the Erlang port
+     * mapper, thus preventing any new connections from remote nodes.
      */
     public void unPublishPort() {
         // unregister with epmd
@@ -265,18 +279,18 @@ public class OtpSelf extends OtpLocalNode {
     }
 
     /**
-     * Accept an incoming connection from a remote node. A call to this method will block
-     * until an incoming connection is at least attempted.
+     * Accept an incoming connection from a remote node. A call to this method
+     * will block until an incoming connection is at least attempted.
      *
      * @return a connection to a remote node.
      *
      * @exception java.io.IOException
-     *                if a remote node attempted to connect but no common protocol was
-     *                found.
+     *                if a remote node attempted to connect but no common
+     *                protocol was found.
      *
      * @exception OtpAuthException
-     *                if a remote node attempted to connect, but was not authorized to
-     *                connect.
+     *                if a remote node attempted to connect, but was not
+     *                authorized to connect.
      */
     public OtpConnection accept() throws IOException, OtpAuthException {
         OtpTransport newsock = null;
@@ -314,8 +328,8 @@ public class OtpSelf extends OtpLocalNode {
      * @exception OtpAuthException
      *                if the connection was refused by the remote node.
      */
-    public OtpConnection connect(final OtpPeer other)
-            throws IOException, UnknownHostException, OtpAuthException {
+    public OtpConnection connect(final OtpPeer other) throws IOException,
+            UnknownHostException, OtpAuthException {
         return new OtpConnection(this, other);
     }
 }

--- a/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpServer.java
+++ b/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpServer.java
@@ -1,17 +1,19 @@
 /*
  * %CopyrightBegin%
  *
- * Copyright Ericsson AB 2000-2016. All Rights Reserved.
+ * Copyright Ericsson AB 2000-2022. All Rights Reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
- * file except in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under
- * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * %CopyrightEnd%
  */
@@ -20,18 +22,18 @@ package com.ericsson.otp.erlang;
 import java.io.IOException;
 
 /**
- * Represents a local OTP client or server node. It is used when you want other nodes to
- * be able to establish connections to this one.
+ * Represents a local OTP client or server node. It is used when you want other
+ * nodes to be able to establish connections to this one.
  *
- * When you create an instance of this class, it will bind a socket to a port so that
- * incoming connections can be accepted. However the port number will not be made
- * available to other nodes wishing to connect until you explicitely register with the
- * port mapper daemon by calling {@link #publishPort()}.
+ * When you create an instance of this class, it will bind a socket to a port so
+ * that incoming connections can be accepted. However the port number will not
+ * be made available to other nodes wishing to connect until you explicitly
+ * register with the port mapper daemon by calling {@link #publishPort()}.
  *
  * <p>
- * When the Java node will be connecting to a remote Erlang, Java or C node, it must first
- * identify itself as a node by creating an instance of this class, after which it may
- * connect to the remote node.
+ * When the Java node will be connecting to a remote Erlang, Java or C node, it
+ * must first identify itself as a node by creating an instance of this class,
+ * after which it may connect to the remote node.
  *
  * <p>
  * Setting up a connection may be done as follows:
@@ -46,7 +48,8 @@ import java.io.IOException;
  *
  * @see OtpSelf
  *
- * @deprecated the functionality of this class has been moved to {@link OtpSelf} .
+ * @deprecated the functionality of this class has been moved to {@link OtpSelf}
+ *             .
  */
 @Deprecated
 public class OtpServer extends OtpSelf {
@@ -65,15 +68,16 @@ public class OtpServer extends OtpSelf {
     }
 
     /**
-     * Create an OtpServer, using a vacant port chosen by the operating system. To
-     * determine what port was chosen, call the object's {@link #port()} method.
+     * Create an OtpServer, using a vacant port chosen by the operating system.
+     * To determine what port was chosen, call the object's {@link #port()}
+     * method.
      *
      * @param node
      *            the name of the node.
      *
      * @param cookie
-     *            the authorization cookie that will be used by this node when accepts
-     *            connections from remote nodes.
+     *            the authorization cookie that will be used by this node when
+     *            accepts connections from remote nodes.
      *
      * @exception java.io.IOException
      *                if a ServerSocket could not be created.
@@ -90,15 +94,15 @@ public class OtpServer extends OtpSelf {
      *            a name for this node, as above.
      *
      * @param cookie
-     *            the authorization cookie that will be used by this node when accepts
-     *            connections from remote nodes.
+     *            the authorization cookie that will be used by this node when
+     *            accepts connections from remote nodes.
      *
      * @param port
      *            the port number to bind the socket to.
      *
      * @exception java.io.IOException
-     *                if a ServerSocket could not be created or if the chosen port number
-     *                was not available.
+     *                if a ServerSocket could not be created or if the chosen
+     *                port number was not available.
      *
      */
     public OtpServer(final String node, final String cookie, final int port)

--- a/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpServerSocketTransport.java
+++ b/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpServerSocketTransport.java
@@ -3,15 +3,17 @@
  *
  * Copyright Ericsson AB 2015. All Rights Reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
- * file except in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under
- * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * %CopyrightEnd%
  */
@@ -24,7 +26,7 @@ import java.net.Socket;
 
 /**
  * Default socket-based server transport
- *
+ * 
  * @author Dmitriy Kargapolov
  */
 public class OtpServerSocketTransport implements OtpServerTransport {
@@ -44,7 +46,6 @@ public class OtpServerSocketTransport implements OtpServerTransport {
     /**
      * @see ServerSocket#getLocalPort()
      */
-    @Override
     public int getLocalPort() {
         return socket.getLocalPort();
     }
@@ -52,7 +53,6 @@ public class OtpServerSocketTransport implements OtpServerTransport {
     /**
      * @see ServerSocket#accept()
      */
-    @Override
     public OtpTransport accept() throws IOException {
         final Socket sock = socket.accept();
         sock.setTcpNoDelay(true);
@@ -62,7 +62,6 @@ public class OtpServerSocketTransport implements OtpServerTransport {
     /**
      * @see ServerSocket#close()
      */
-    @Override
     public void close() throws IOException {
         socket.close();
     }

--- a/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpServerTransport.java
+++ b/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpServerTransport.java
@@ -3,15 +3,17 @@
  *
  * Copyright Ericsson AB 2015. All Rights Reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
- * file except in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under
- * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * %CopyrightEnd%
  */
@@ -23,7 +25,7 @@ import java.net.ServerSocket;
 
 /**
  * Server-side connection-oriented transport interface.
- *
+ * 
  * @author Dmitriy Kargapolov
  */
 public interface OtpServerTransport {

--- a/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpSocketTransport.java
+++ b/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpSocketTransport.java
@@ -3,15 +3,17 @@
  *
  * Copyright Ericsson AB 2015. All Rights Reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
- * file except in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under
- * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * %CopyrightEnd%
  */
@@ -27,7 +29,7 @@ import java.net.UnknownHostException;
 
 /**
  * Default socket-based client transport
- *
+ * 
  * @author Dmitriy Kargapolov
  */
 public class OtpSocketTransport implements OtpTransport {
@@ -57,7 +59,7 @@ public class OtpSocketTransport implements OtpTransport {
 
     /**
      * Socket wrapping constructor
-     *
+     * 
      * @param s
      *            socket to wrap
      */
@@ -68,7 +70,6 @@ public class OtpSocketTransport implements OtpTransport {
     /**
      * @see Socket#getInputStream()
      */
-    @Override
     public InputStream getInputStream() throws IOException {
         return socket.getInputStream();
     }
@@ -76,7 +77,6 @@ public class OtpSocketTransport implements OtpTransport {
     /**
      * @see Socket#getOutputStream()
      */
-    @Override
     public OutputStream getOutputStream() throws IOException {
         return socket.getOutputStream();
     }
@@ -84,7 +84,6 @@ public class OtpSocketTransport implements OtpTransport {
     /**
      * @see Socket#close()
      */
-    @Override
     public void close() throws IOException {
         socket.close();
     }

--- a/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpSocketTransportFactory.java
+++ b/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpSocketTransportFactory.java
@@ -3,15 +3,17 @@
  *
  * Copyright Ericsson AB 2015. All Rights Reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
- * file except in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under
- * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * %CopyrightEnd%
  */
@@ -23,7 +25,7 @@ import java.net.InetAddress;
 
 /**
  * Default socket-based transport factory
- *
+ * 
  * @author Dmitriy Kargapolov
  */
 public class OtpSocketTransportFactory implements OtpTransportFactory {
@@ -31,7 +33,6 @@ public class OtpSocketTransportFactory implements OtpTransportFactory {
     /**
      * @see OtpTransportFactory#createTransport(String, int)
      */
-    @Override
     public OtpTransport createTransport(final String addr, final int port)
             throws IOException {
         return new OtpSocketTransport(addr, port);
@@ -40,7 +41,6 @@ public class OtpSocketTransportFactory implements OtpTransportFactory {
     /**
      * @see OtpTransportFactory#createTransport(InetAddress, int)
      */
-    @Override
     public OtpTransport createTransport(final InetAddress addr, final int port)
             throws IOException {
         return new OtpSocketTransport(addr, port);
@@ -49,8 +49,8 @@ public class OtpSocketTransportFactory implements OtpTransportFactory {
     /**
      * @see OtpTransportFactory#createServerTransport(int)
      */
-    @Override
-    public OtpServerTransport createServerTransport(final int port) throws IOException {
+    public OtpServerTransport createServerTransport(final int port)
+            throws IOException {
         return new OtpServerSocketTransport(port);
     }
 

--- a/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpSystem.java
+++ b/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpSystem.java
@@ -3,15 +3,17 @@
  *
  * Copyright Ericsson AB 2004-2016. All Rights Reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
- * file except in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under
- * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * %CopyrightEnd%
  */

--- a/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpTransport.java
+++ b/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpTransport.java
@@ -3,15 +3,17 @@
  *
  * Copyright Ericsson AB 2015. All Rights Reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
- * file except in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under
- * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * %CopyrightEnd%
  */
@@ -25,7 +27,7 @@ import java.net.Socket;
 
 /**
  * Client-side connection-oriented transport interface.
- *
+ * 
  * @author Dmitriy Kargapolov
  */
 public interface OtpTransport {
@@ -33,16 +35,16 @@ public interface OtpTransport {
     /**
      * @see Socket#getInputStream()
      */
-    InputStream getInputStream() throws IOException;
+    public abstract InputStream getInputStream() throws IOException;
 
     /**
      * @see Socket#getOutputStream()
      */
-    OutputStream getOutputStream() throws IOException;
+    public abstract OutputStream getOutputStream() throws IOException;
 
     /**
      * @see Socket#close()
      */
-    void close() throws IOException;
+    public abstract void close() throws IOException;
 
 }

--- a/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpTransportFactory.java
+++ b/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/OtpTransportFactory.java
@@ -3,15 +3,17 @@
  *
  * Copyright Ericsson AB 2015. All Rights Reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
- * file except in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under
- * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  * %CopyrightEnd%
  */
@@ -22,68 +24,71 @@ import java.io.IOException;
 import java.net.InetAddress;
 
 /**
- * Factory class used to create client- and server-side transport instances. One static
- * instance of class implementing this interface is created when program loaded. Default
- * implementation used is {@link OtpSocketTransportFactory}. JInterface user can specify
- * custom transport factory implementing this interface in the following ways:
+ * Factory class used to create client- and server-side transport instances. One
+ * static instance of class implementing this interface is created when program
+ * loaded. Default implementation used is {@link OtpSocketTransportFactory}.
+ * JInterface user can specify custom transport factory implementing this
+ * interface in the following ways:
  * <dl>
  * <dt>defining static class as internal to class holding main() method</dt>
  * <dd>In the systems, where main class can be retrieved with
- * <code>System.getProperty("sun.java.command")</code>, user can define static class
- * <b>OtpErlangSystemTuner</b> internal to the main class, providing at least one static
- * method with the name <b>getOtpTransportFactory</b>, with no parameters, returning
- * object of class implementing <b>OtpTransportFactory</b>, for example:
- *
+ * <code>System.getProperty("sun.java.command")</code>, user can define static
+ * class <b>OtpErlangSystemTuner</b> internal to the main class, providing at
+ * least one static method with the name <b>getOtpTransportFactory</b>, with no
+ * parameters, returning object of class implementing
+ * <b>OtpTransportFactory</b>, for example:
+ * 
  * <pre>
- *
+ * 
  * public class MyMainClass {
- *
+ * 
  *     public static class OtpErlangSystemTuner {
  *         ...
  *         public static OtpTransportFactory getOtpTransportFactory() {
  *             return new MyTransportFactory();
  *         }
  *     }
- *
+ * 
  *     public static class MyTransportFactory implements OtpTransportFactory {
  *         ...
  *     }
- *
+ * 
  *     public static void main(String[] args) {
  *         ...
  *     }
  * }
- *
- *
+ * 
+ * 
  * </pre>
- *
+ * 
  * </dd>
- *
+ * 
  * <dt>specifying factory class in the system properties</dt>
  * <dd>User-defined transport factory class may be specified via system property
  * <b>OtpTransportFactory</b>, for example:
- *
+ * 
  * <pre>
- *
+ * 
  * package com.my.company;
- *
+ * 
  * public static class MyTransportFactory implements OtpTransportFactory {
  *     ...
  * }
  * </pre>
- *
+ * 
  * In such case program may be run with
- * -DOtpTransportFactory=com.my.company.MyTransportFactory, or other way of setting system
- * property <i>before execution of static initializers</i> may be used.</dd>
+ * -DOtpTransportFactory=com.my.company.MyTransportFactory, or other way of
+ * setting system property <i>before execution of static initializers</i> may be
+ * used.</dd>
  * </dl>
- *
+ * 
  * @author Dmitriy Kargapolov
  */
 public interface OtpTransportFactory {
 
     /**
      * Create instance of {@link OtpTransport}
-     *
+     * 
      * @param addr
      *            host name or IP address string
      * @param port
@@ -91,11 +96,12 @@ public interface OtpTransportFactory {
      * @return new socket object
      * @throws IOException
      */
-    OtpTransport createTransport(String addr, int port) throws IOException;
+    public abstract OtpTransport createTransport(String addr, int port)
+            throws IOException;
 
     /**
      * Create instance of {@link OtpTransport}
-     *
+     * 
      * @param addr
      *            peer address
      * @param port
@@ -103,15 +109,17 @@ public interface OtpTransportFactory {
      * @return new socket object
      * @throws IOException
      */
-    OtpTransport createTransport(InetAddress addr, int port) throws IOException;
+    public abstract OtpTransport createTransport(InetAddress addr, int port)
+            throws IOException;
 
     /**
      * Create instance of {@link OtpServerTransport}
-     *
+     * 
      * @param port
      *            port number to listen on
      * @return new socket object
      * @throws IOException
      */
-    OtpServerTransport createServerTransport(int port) throws IOException;
+    public OtpServerTransport createServerTransport(int port)
+            throws IOException;
 }

--- a/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/java_files
+++ b/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/java_files
@@ -1,0 +1,93 @@
+# -*-Makefile-*-
+
+#
+# %CopyrightBegin%
+#
+# Copyright Ericsson AB 2000-2022. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# %CopyrightEnd%
+#
+
+# this file is included in the doc and src makefiles
+# so the list of files only needs to be updated in one place
+# i.e. here
+
+EXCEPTIONS = \
+	OtpAuthException \
+	OtpErlangDecodeException \
+	OtpErlangException \
+	OtpErlangExit \
+	OtpErlangRangeException \
+	OtpException
+
+COMM = \
+	AbstractConnection \
+	AbstractNode \
+	GenericQueue \
+	Link \
+	Links \
+	OtpConnection \
+	OtpCookedConnection \
+	OtpEpmd \
+	OtpErlangFun \
+	OtpErlangExternalFun \
+	OtpExternal \
+	OtpGenericTransportFactory \
+	OtpInputStream \
+	OtpLocalNode \
+	OtpNodeStatus \
+	OtpMD5 \
+	OtpMbox \
+	OtpMsg \
+	OtpNode \
+	OtpOutputStream \
+	OtpPeer \
+	OtpSelf \
+	OtpServer \
+	OtpServerSocketTransport \
+	OtpServerTransport \
+	OtpSocketTransport \
+	OtpSocketTransportFactory \
+	OtpTransport \
+	OtpTransportFactory
+
+ERL = \
+	OtpErlangAtom \
+	OtpErlangBinary \
+	OtpErlangBitstr \
+	OtpErlangBoolean \
+	OtpErlangByte \
+	OtpErlangChar \
+	OtpErlangDouble \
+	OtpErlangFloat \
+	OtpErlangInt \
+	OtpErlangList \
+	OtpErlangLong \
+	OtpErlangObject \
+	OtpErlangPid \
+	OtpErlangPort \
+	OtpErlangRef \
+	OtpErlangShort\
+	OtpErlangString\
+	OtpErlangTuple \
+	OtpErlangMap \
+	OtpErlangUInt \
+	OtpErlangUShort
+
+MISC = \
+	OtpSystem
+
+JAVA_FILES=$(EXCEPTIONS) $(ERL) $(COMM) $(MISC)
+

--- a/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/jinterface.app.src
+++ b/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/jinterface.app.src
@@ -1,0 +1,33 @@
+%%
+%% %CopyrightBegin%
+%% 
+%% Copyright Ericsson AB 2014-2016. All Rights Reserved.
+%% 
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%% 
+%% %CopyrightEnd%
+%%
+%% This is an -*- erlang -*- file.
+%%
+
+{application, jinterface,
+ [
+  {description, "Jinterface"},
+  {vsn, "%VSN%"},
+  {modules, []},
+  {registered, []},
+  {applications, []},
+  {env, []},
+  {runtime_dependencies, []}
+ ]
+}.

--- a/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/jinterface.appup.src
+++ b/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/jinterface.appup.src
@@ -1,0 +1,19 @@
+%% -*- erlang -*-
+%% %CopyrightBegin%
+%% 
+%% Copyright Ericsson AB 2014-2016. All Rights Reserved.
+%% 
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%% 
+%% %CopyrightEnd%
+{"%VSN%", [], []}.

--- a/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/package.html
+++ b/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/package.html
@@ -1,0 +1,158 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
+<!-- 
+  
+  %CopyrightBegin%
+  
+  Copyright Ericsson AB 2000-2022. All Rights Reserved.
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+ 
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  
+  %CopyrightEnd%
+-->
+<html>
+<head>
+<!--
+
+  File: package.html
+
+  Copyright ...
+
+-->
+</head>
+<body bgcolor="white">
+
+<p> This package provides support for communication with Erlang and
+representation of Erlang datatypes.
+
+<p><em>Note:</em> By default, <code>jinterface</code> is only guaranteed
+to be compatible with other Erlang/OTP components from the same release as
+<code>jinterface</code> itself. For example, <code>jinterface</code>
+from the OTP R10 release is not compatible with an Erlang emulator from
+the OTP R9 release by default. <code>jinterface</code> can be set in
+compatibility mode of an earlier release (not earlier that R7), though.
+The compatibility mode is set by usage of the <code>OtpCompatRel</code>
+property. By starting the jvm with the command-line argument
+<code>-DOtpCompatRel=9</code>, <code>jinterface</code> will be compatible
+with the R9 release of OTP. <em>Warning!</em> You may run into trouble if
+this feature is used carelessly. Always make sure that all communicating
+components are either from the same Erlang/OTP release, or from release
+X and release Y where all components from release Y are in compatibility
+mode of release X.
+
+<p> The classes 
+{@link com.ericsson.otp.erlang.OtpErlangList}, 
+{@link com.ericsson.otp.erlang.OtpErlangTuple},
+{@link com.ericsson.otp.erlang.OtpErlangBinary},
+{@link com.ericsson.otp.erlang.OtpErlangAtom},
+{@link com.ericsson.otp.erlang.OtpErlangBoolean},
+{@link com.ericsson.otp.erlang.OtpErlangByte},
+{@link com.ericsson.otp.erlang.OtpErlangChar},
+{@link com.ericsson.otp.erlang.OtpErlangDouble},
+{@link com.ericsson.otp.erlang.OtpErlangFloat},
+{@link com.ericsson.otp.erlang.OtpErlangLong},
+{@link com.ericsson.otp.erlang.OtpErlangInt},
+{@link com.ericsson.otp.erlang.OtpErlangUInt},
+{@link com.ericsson.otp.erlang.OtpErlangShort},
+{@link com.ericsson.otp.erlang.OtpErlangUShort},
+{@link com.ericsson.otp.erlang.OtpErlangString},
+{@link com.ericsson.otp.erlang.OtpErlangObject},
+{@link com.ericsson.otp.erlang.OtpErlangPid},
+{@link com.ericsson.otp.erlang.OtpErlangPort},
+and {@link com.ericsson.otp.erlang.OtpErlangRef}
+represent the various Erlang datatypes.
+
+
+<p> There are two basic mechanisms for communicating with Erlang,
+described briefly here. Note that the two mechanisms are not intended
+to be used together. Which mechanism you choose depends on your
+application and the level of control it needs. </p>
+
+<p> You can use {@link com.ericsson.otp.erlang.OtpNode}, which can
+manage incoming and outgoing connections for you. With {@link
+com.ericsson.otp.erlang.OtpNode} a thread is automatically started to
+listen for incoming connections, make necessary outgoing connections,
+and dispatch messages to their recipients. {@link
+com.ericsson.otp.erlang.OtpNode} supports the concept of {@link
+com.ericsson.otp.erlang.OtpMbox mailboxes}, allowing you to have
+several Java components communicating independently with Erlang.
+</p>
+
+<pre>
+  OtpNode node = new OtpNode("bingo");
+  OtpMbox mbox = node.createMbox();
+  
+  mbox.send("foo@localhost",new OtpErlangAtom("hej"));
+</pre>
+
+<p> If you need more control (but less support from the library), you
+can manage connections yourself using the {@link
+com.ericsson.otp.erlang.OtpSelf} and {@link
+com.ericsson.otp.erlang.OtpConnection} classes, in which case you can
+control explicitly which connections are made and which messages are
+sent. Received messages are not dispatched by {@link
+com.ericsson.otp.erlang.OtpConnection}. </p>
+
+<p> The classes {@link com.ericsson.otp.erlang.OtpPeer}, {@link
+com.ericsson.otp.erlang.OtpSelf} and {@link
+com.ericsson.otp.erlang.OtpServer} are used to represent OTP nodes and
+are necessary in order to set up communication between the Java
+thread and a remote node. Once a connection has been established, it
+is represented by an {@link com.ericsson.otp.erlang.OtpConnection},
+through which all communication goes.
+
+<p> Setting up a connection with a remote node is straightforward. You
+create objects representing the local and remote nodes, then call the
+local node's {@link
+com.ericsson.otp.erlang.OtpSelf#connect(com.ericsson.otp.erlang.OtpPeer)
+connect()} method:
+
+<pre>
+  OtpSelf self = new OtpSelf("client","cookie");
+  OtpPeer other = new OtpPeer("server");
+  OtpConnection conn = self.connect(other);
+</pre>
+
+<p>If you wish to be able to accept incoming connections as well as
+make outgoing ones, you first must register the listen port with EPMD
+(described in the Erlang documentation). Once that is done, you can
+accept incoming connections:
+
+<pre>
+  OtpServer self = new OtpSelf("server","cookie");
+  self.publishPort();
+  OtpConnection conn = self.accept();
+</pre>
+
+
+<p>Once the connection is established by one of the above methods ({@link
+com.ericsson.otp.erlang.OtpSelf#connect(com.ericsson.otp.erlang.OtpPeer)
+connect()} or {@link com.ericsson.otp.erlang.OtpSelf#accept()
+accept()}), you can use the resulting {@link
+com.ericsson.otp.erlang.OtpConnection OtpConnection} to send and
+receive messages:
+
+<pre>
+  OtpErlangAtom msg = new ErlangOtpAtom("hello");
+  conn.send("echoserver", msg);
+  
+  OtpErlangObject reply = conn.receive();
+  System.out.println("Received " + reply);
+</pre>
+
+<p> Finally, you can get an even greater level of control (and even
+less support from the library) by subclassing {@link
+com.ericsson.otp.erlang.AbstractConnection} and implementing the
+communication primitives needed by your application. </p>
+
+</body>
+</html>

--- a/libs/com.google.truth/pom.xml
+++ b/libs/com.google.truth/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.erlide</groupId>
 		<artifactId>org.erlide.parent</artifactId>
-		<version>0.60.4-SNAPSHOT</version>
+		<version>0.61.0-SNAPSHOT</version>
 		<relativePath>../..</relativePath>
 	</parent>
 

--- a/libs/pom.xml
+++ b/libs/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.erlide</groupId>
     <artifactId>org.erlide.parent</artifactId>
-    <version>0.60.4-SNAPSHOT</version>
+    <version>0.61.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/plugins/org.erlide.backend/META-INF/MANIFEST.MF
+++ b/plugins/org.erlide.backend/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.erlide.backend;singleton:=true
-Bundle-Version: 0.60.4.qualifier
+Bundle-Version: 0.61.0.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/plugins/org.erlide.backend/pom.xml
+++ b/plugins/org.erlide.backend/pom.xml
@@ -6,12 +6,12 @@
 	<parent>
 		<groupId>org.erlide</groupId>
 		<artifactId>org.erlide.parent</artifactId>
-		<version>0.60.4-SNAPSHOT</version>
+		<version>0.61.0-SNAPSHOT</version>
 		<relativePath>../..</relativePath>
 	</parent>
 
 	<artifactId>org.erlide.backend</artifactId>
-	<version>0.60.4-SNAPSHOT</version>
+	<version>0.61.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 </project>

--- a/plugins/org.erlide.branding/META-INF/MANIFEST.MF
+++ b/plugins/org.erlide.branding/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: erlide - Erlang language tools
 Bundle-SymbolicName: org.erlide.branding;singleton:=true
-Bundle-Version: 0.60.4.qualifier
+Bundle-Version: 0.61.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.7.0",
  org.eclipse.ui.intro.universal;bundle-version="3.2.500",

--- a/plugins/org.erlide.branding/p2.inf
+++ b/plugins/org.erlide.branding/p2.inf
@@ -1,5 +1,5 @@
-instructions.configure=org.eclipse.equinox.p2.touchpoint.eclipse.addRepository(location:http${#58}//download.erlide.org/update/,type:0,name:Erlide site,enabled:true); \
-  org.eclipse.equinox.p2.touchpoint.eclipse.addRepository(location:http${#58}//download.erlide.org/update/,type:1,name:Erlide site,enabled:true); \
+instructions.configure=org.eclipse.equinox.p2.touchpoint.eclipse.addRepository(location:http${#58}//erlide.org/update/,type:0,name:Erlide site,enabled:true); \
+  org.eclipse.equinox.p2.touchpoint.eclipse.addRepository(location:http${#58}//erlide.org/update/,type:1,name:Erlide site,enabled:true); \
   org.eclipse.equinox.p2.touchpoint.eclipse.addRepository(location:http${#58}//download.eclipse.org/releases/juno/,type:0,name:Eclipse Juno,enabled:true); \
   org.eclipse.equinox.p2.touchpoint.eclipse.addRepository(location:http${#58}//download.eclipse.org/releases/juno/,type:1,name:Eclipse Juno,enabled:true);
   

--- a/plugins/org.erlide.branding/pom.xml
+++ b/plugins/org.erlide.branding/pom.xml
@@ -5,12 +5,12 @@
   <parent>
     <groupId>org.erlide</groupId>
     <artifactId>org.erlide.parent</artifactId>
-        <version>0.60.4-SNAPSHOT</version>
+        <version>0.61.0-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 
   <artifactId>org.erlide.branding</artifactId>
-  <version>0.60.4-SNAPSHOT</version>
+  <version>0.61.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
     <build>

--- a/plugins/org.erlide.core/META-INF/MANIFEST.MF
+++ b/plugins/org.erlide.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.erlide.core; singleton:=true
-Bundle-Version: 0.60.4.qualifier
+Bundle-Version: 0.61.0.qualifier
 Bundle-Activator: org.erlide.core.ErlangPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/plugins/org.erlide.core/pom.xml
+++ b/plugins/org.erlide.core/pom.xml
@@ -6,12 +6,12 @@
 	<parent>
 		<groupId>org.erlide</groupId>
 		<artifactId>org.erlide.parent</artifactId>
-		<version>0.60.4-SNAPSHOT</version>
+		<version>0.61.0-SNAPSHOT</version>
 		<relativePath>../..</relativePath>
 	</parent>
 
 	<artifactId>org.erlide.core</artifactId>
-	<version>0.60.4-SNAPSHOT</version>
+	<version>0.61.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 </project>

--- a/plugins/org.erlide.cover.api/META-INF/MANIFEST.MF
+++ b/plugins/org.erlide.cover.api/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Cover Interfaces
 Bundle-SymbolicName: org.erlide.cover.api;singleton:=true
-Bundle-Version: 0.60.4.qualifier
+Bundle-Version: 0.61.0.qualifier
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.core.resources,
  org.erlide.model.api,

--- a/plugins/org.erlide.cover.api/pom.xml
+++ b/plugins/org.erlide.cover.api/pom.xml
@@ -5,11 +5,11 @@
   <parent>
     <groupId>org.erlide</groupId>
     <artifactId>org.erlide.parent</artifactId>
-        <version>0.60.4-SNAPSHOT</version>
+        <version>0.61.0-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 
   <artifactId>org.erlide.cover.api</artifactId>
-  <version>0.60.4-SNAPSHOT</version>
+  <version>0.61.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/plugins/org.erlide.cover.core/META-INF/MANIFEST.MF
+++ b/plugins/org.erlide.cover.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Cover suport for ErlIde (Core plugin)
 Bundle-SymbolicName: org.erlide.cover.core;singleton:=true
-Bundle-Version: 0.60.4.qualifier
+Bundle-Version: 0.61.0.qualifier
 Bundle-Activator: org.erlide.cover.core.Activator
 Bundle-Vendor: Erlang Solutions
 Require-Bundle: org.eclipse.core.runtime,

--- a/plugins/org.erlide.cover.core/pom.xml
+++ b/plugins/org.erlide.cover.core/pom.xml
@@ -5,11 +5,11 @@
   <parent>
     <groupId>org.erlide</groupId>
     <artifactId>org.erlide.parent</artifactId>
-        <version>0.60.4-SNAPSHOT</version>
+        <version>0.61.0-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 
   <artifactId>org.erlide.cover.core</artifactId>
-  <version>0.60.4-SNAPSHOT</version>
+  <version>0.61.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/plugins/org.erlide.cover.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.erlide.cover.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Cover plugin UI
 Bundle-SymbolicName: org.erlide.cover.ui;singleton:=true
-Bundle-Version: 0.60.4.qualifier
+Bundle-Version: 0.61.0.qualifier
 Bundle-Activator: org.erlide.cover.ui.Activator
 Bundle-Vendor: Erlang Solutions
 Require-Bundle: org.eclipse.ui,

--- a/plugins/org.erlide.cover.ui/pom.xml
+++ b/plugins/org.erlide.cover.ui/pom.xml
@@ -5,12 +5,12 @@
   <parent>
     <groupId>org.erlide</groupId>
     <artifactId>org.erlide.parent</artifactId>
-        <version>0.60.4-SNAPSHOT</version>
+        <version>0.61.0-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 
   <artifactId>org.erlide.cover.ui</artifactId>
-  <version>0.60.4-SNAPSHOT</version>
+  <version>0.61.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
 </project>

--- a/plugins/org.erlide.help/META-INF/MANIFEST.MF
+++ b/plugins/org.erlide.help/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.erlide.help; singleton:=true
-Bundle-Version: 0.60.4.qualifier
+Bundle-Version: 0.61.0.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.help;bundle-version="[3.6.0,4.0.0)",

--- a/plugins/org.erlide.help/articles/eclipse/120_Installing-and-updating.md
+++ b/plugins/org.erlide.help/articles/eclipse/120_Installing-and-updating.md
@@ -6,17 +6,16 @@ part: Getting started
 
 # Installing and updating
 
-* Install Erlang __R20__ or later, if it isn't already present on your system. On Windows systems, use a path with no spaces in it.
+* Install Erlang __R23__ or later, if it isn't already present on your system. On Windows systems, use a path with no spaces in it.
 * Install Eclipse. We target primarily version __4.8__, later versions work just as well. __Java 8__ is required.
 * If your network uses a proxy to connect to the internet, fill in the appropriate data in `Window -> Preferences -> Install/Update -> Proxy settings`
 * Install Erlide by going to `Help -> Software Updates -> Find` and `Install... -> Search for new features to install`.
-* In the dialog, choose New remote site and enter `Erlide` as name and `https://download.erlide.org/update` as URL.
+* In the dialog, choose New remote site and enter `Erlide` as name and `https://erlide.org/update` as URL.
 * Select `Erlang IDE` and maybe the optional add-ins. Press `Next`, again `Next`, accept the license agreement and `Finish`. You may be asked to agree to install unsigned content, do so.
 * Restart. Go to `Window -> Preferences -> Erlang -> Installed runtimes` and add an entry (or several) for your Erlang installation(s) of choice. The required parameters are the name and the path to the top level directory (i.e. `$ERL_TOP`). Now restart again.
 * Done! You're ready to start exploring.
 
 ## Update sites
 
-* Stable releases: [https://download.erlide.org/update](https://download.erlide.org/update)
-* Beta releases: [https://download.erlide.org/update/beta](https://download.erlide.org/update/beta)
-* Nightly releases (bleeding edge, may not work, use at your own risk): [https://download.erlide.org/update/nightly](https://download.erlide.org/update/nightly)
+* Stable releases: [https://erlide.org/update](https://erlide.org/update)
+* Prerelease: [https://erlide.org/update/prerelease](https://erlide.org/update/prerelease)

--- a/plugins/org.erlide.help/articles/eclipse/developer/3b0_Building-and-distributing.md
+++ b/plugins/org.erlide.help/articles/eclipse/developer/3b0_Building-and-distributing.md
@@ -8,12 +8,10 @@ part: Developer's guide
 
 There are three update sites:
 
--   `https://download.erlide.org/update` : contains all stable releases
--   `https://download.erlide.org/update/beta` : contains the release the will be
+-   `https://erlide.org/update` : contains all stable releases
+-   `https://erlide.org/update/prerelease` : contains the release that will be
     promoted to stable once it passes acceptance tests. May be broken at
     times, but not for long.
--   `https://download.erlide.org/update/nightly` : contains the latest and
-    greatest, but untested code. Use it at your own risk.
 
 ## Building Erlide
 

--- a/plugins/org.erlide.help/pom.xml
+++ b/plugins/org.erlide.help/pom.xml
@@ -6,12 +6,12 @@
 	<parent>
 		<groupId>org.erlide</groupId>
 		<artifactId>org.erlide.parent</artifactId>
-		<version>0.60.4-SNAPSHOT</version>
+		<version>0.61.0-SNAPSHOT</version>
 		<relativePath>../..</relativePath>
 	</parent>
 
 	<artifactId>org.erlide.help</artifactId>
-	<version>0.60.4-SNAPSHOT</version>
+	<version>0.61.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 	<profiles>

--- a/plugins/org.erlide.model.api/META-INF/MANIFEST.MF
+++ b/plugins/org.erlide.model.api/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: erlide engine api
 Bundle-SymbolicName: org.erlide.model.api;singleton:=true
-Bundle-Version: 0.60.4.qualifier
+Bundle-Version: 0.61.0.qualifier
 Bundle-Vendor: erlide.org
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.erlide.engine,

--- a/plugins/org.erlide.model.api/pom.xml
+++ b/plugins/org.erlide.model.api/pom.xml
@@ -6,12 +6,12 @@
 	<parent>
 		<groupId>org.erlide</groupId>
 		<artifactId>org.erlide.parent</artifactId>
-        <version>0.60.4-SNAPSHOT</version>
+        <version>0.61.0-SNAPSHOT</version>
 		<relativePath>../..</relativePath>
 	</parent>
 
 	<artifactId>org.erlide.model.api</artifactId>
-	<version>0.60.4-SNAPSHOT</version>
+	<version>0.61.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 </project>

--- a/plugins/org.erlide.model.api/src/org/erlide/engine/model/root/ProjectPreferencesConstants.java
+++ b/plugins/org.erlide.model.api/src/org/erlide/engine/model/root/ProjectPreferencesConstants.java
@@ -33,10 +33,9 @@ public final class ProjectPreferencesConstants {
     public static final String DEFAULT_EXTERNAL_INCLUDES = "";
 
     public static final String RUNTIME_VERSION = "backend_version";
-    public static final RuntimeVersion DEFAULT_RUNTIME_VERSION = new RuntimeVersion(21);
-    public static final RuntimeVersion[] SUPPORTED_VERSIONS = { new RuntimeVersion(19),
-            new RuntimeVersion(20), new RuntimeVersion(21), new RuntimeVersion(22),
-            new RuntimeVersion(23) };
+    public static final RuntimeVersion DEFAULT_RUNTIME_VERSION = new RuntimeVersion(23);
+    public static final RuntimeVersion[] SUPPORTED_VERSIONS = { new RuntimeVersion(23),
+            new RuntimeVersion(24), new RuntimeVersion(25) };
     public static final RuntimeVersion FALLBACK_RUNTIME_VERSION = ProjectPreferencesConstants.SUPPORTED_VERSIONS[0];
 
     public static final String PROJECT_EXTERNAL_MODULES = "external_modules";

--- a/plugins/org.erlide.model/META-INF/MANIFEST.MF
+++ b/plugins/org.erlide.model/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: erlide model
 Bundle-SymbolicName: org.erlide.model;singleton:=true
-Bundle-Version: 0.60.4.qualifier
+Bundle-Version: 0.61.0.qualifier
 Bundle-Vendor: erlide.org project
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.10.0",
  org.eclipse.core.resources;bundle-version="3.7.0",

--- a/plugins/org.erlide.model/pom.xml
+++ b/plugins/org.erlide.model/pom.xml
@@ -6,12 +6,12 @@
 	<parent>
 		<groupId>org.erlide</groupId>
 		<artifactId>org.erlide.parent</artifactId>
-        <version>0.60.4-SNAPSHOT</version>
+        <version>0.61.0-SNAPSHOT</version>
 		<relativePath>../..</relativePath>
 	</parent>
 
 	<artifactId>org.erlide.model</artifactId>
-	<version>0.60.4-SNAPSHOT</version>
+	<version>0.61.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
     <build>

--- a/plugins/org.erlide.runtime/META-INF/MANIFEST.MF
+++ b/plugins/org.erlide.runtime/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Erlang backend support (no eclipse dependencies)
 Bundle-SymbolicName: org.erlide.runtime;singleton:=true
-Bundle-Version: 0.60.4.qualifier
+Bundle-Version: 0.61.0.qualifier
 Bundle-Vendor: erlide.org
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.erlide.util,

--- a/plugins/org.erlide.runtime/pom.xml
+++ b/plugins/org.erlide.runtime/pom.xml
@@ -6,12 +6,12 @@
 	<parent>
 		<groupId>org.erlide</groupId>
 		<artifactId>org.erlide.parent</artifactId>
-		<version>0.60.4-SNAPSHOT</version>
+		<version>0.61.0-SNAPSHOT</version>
 		<relativePath>../..</relativePath>
 	</parent>
 
 	<artifactId>org.erlide.runtime</artifactId>
-	<version>0.60.4-SNAPSHOT</version>
+	<version>0.61.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 </project>

--- a/plugins/org.erlide.runtime/src/org/erlide/runtime/runtimeinfo/IRuntimeInfoCatalog.java
+++ b/plugins/org.erlide.runtime/src/org/erlide/runtime/runtimeinfo/IRuntimeInfoCatalog.java
@@ -5,7 +5,7 @@ import java.util.List;
 
 public interface IRuntimeInfoCatalog {
 
-    RuntimeVersion OLDEST_SUPPORTED_VERSION = new RuntimeVersion(17);
+    RuntimeVersion OLDEST_SUPPORTED_VERSION = new RuntimeVersion(23);
 
     Collection<RuntimeInfo> getRuntimes();
 

--- a/plugins/org.erlide.test_support/META-INF/MANIFEST.MF
+++ b/plugins/org.erlide.test_support/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Test frameworks support plug-in
 Bundle-SymbolicName: org.erlide.test_support;singleton:=true
-Bundle-Version: 0.60.4.qualifier
+Bundle-Version: 0.61.0.qualifier
 Bundle-Activator: org.erlide.test_support.Activator
 Bundle-Vendor: erlide.org
 Require-Bundle: org.eclipse.ui,

--- a/plugins/org.erlide.test_support/pom.xml
+++ b/plugins/org.erlide.test_support/pom.xml
@@ -6,11 +6,11 @@
 	<parent>
 		<groupId>org.erlide</groupId>
 		<artifactId>org.erlide.parent</artifactId>
-        <version>0.60.4-SNAPSHOT</version>
+        <version>0.61.0-SNAPSHOT</version>
 		<relativePath>../..</relativePath>
 	</parent>
 
 	<artifactId>org.erlide.test_support</artifactId>
-	<version>0.60.4-SNAPSHOT</version>
+	<version>0.61.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/plugins/org.erlide.tracing.core/META-INF/MANIFEST.MF
+++ b/plugins/org.erlide.tracing.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Erlang tracing for Erlide (java classes)
 Bundle-SymbolicName: org.erlide.tracing.core;singleton:=true
-Bundle-Version: 0.60.4.qualifier
+Bundle-Version: 0.61.0.qualifier
 Bundle-Activator: org.erlide.tracing.core.Activator
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.core.expressions;bundle-version="3.4.300",

--- a/plugins/org.erlide.tracing.core/pom.xml
+++ b/plugins/org.erlide.tracing.core/pom.xml
@@ -6,11 +6,11 @@
 	<parent>
 		<groupId>org.erlide</groupId>
 		<artifactId>org.erlide.parent</artifactId>
-        <version>0.60.4-SNAPSHOT</version>
+        <version>0.61.0-SNAPSHOT</version>
 		<relativePath>../..</relativePath>
 	</parent>
 
 	<artifactId>org.erlide.tracing.core</artifactId>
-	<version>0.60.4-SNAPSHOT</version>
+	<version>0.61.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/plugins/org.erlide.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.erlide.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.erlide.ui; singleton:=true
-Bundle-Version: 0.60.4.qualifier
+Bundle-Version: 0.61.0.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: org.erlide.ui.internal.ErlideUIPlugin
 Bundle-Vendor: %providerName

--- a/plugins/org.erlide.ui/pom.xml
+++ b/plugins/org.erlide.ui/pom.xml
@@ -6,12 +6,12 @@
 	<parent>
 		<groupId>org.erlide</groupId>
 		<artifactId>org.erlide.parent</artifactId>
-        <version>0.60.4-SNAPSHOT</version>
+        <version>0.61.0-SNAPSHOT</version>
 		<relativePath>../..</relativePath>
 	</parent>
 
 	<artifactId>org.erlide.ui</artifactId>
-	<version>0.60.4-SNAPSHOT</version>
+	<version>0.61.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 </project>

--- a/plugins/org.erlide.util/META-INF/MANIFEST.MF
+++ b/plugins/org.erlide.util/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Common code, dependent on Eclipse
 Bundle-SymbolicName: org.erlide.util;singleton:=true
-Bundle-Version: 0.60.4.qualifier
+Bundle-Version: 0.61.0.qualifier
 Bundle-Vendor: erlide.org
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.core.resources,

--- a/plugins/org.erlide.util/pom.xml
+++ b/plugins/org.erlide.util/pom.xml
@@ -6,12 +6,12 @@
 	<parent>
 		<groupId>org.erlide</groupId>
 		<artifactId>org.erlide.parent</artifactId>
-        <version>0.60.4-SNAPSHOT</version>
+        <version>0.61.0-SNAPSHOT</version>
 		<relativePath>../..</relativePath>
 	</parent>
 
 	<artifactId>org.erlide.util</artifactId>
-	<version>0.60.4-SNAPSHOT</version>
+	<version>0.61.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>org.erlide</groupId>
   <artifactId>org.erlide.parent</artifactId>
-  <version>0.60.4-SNAPSHOT</version>
+  <version>0.61.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <properties>
@@ -244,7 +244,7 @@
               <artifact>
                 <groupId>org.erlide</groupId>
                 <artifactId>org.erlide.target</artifactId>
-                <version>0.60.4-SNAPSHOT</version>
+                <version>0.61.0-SNAPSHOT</version>
               </artifact>
             </target>
             <environments>

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
     <repository>
       <id>erlide libs</id>
       <layout>p2</layout>
-      <url>https://download.erlide.org/update/libs</url>
+      <url>https://erlide.org/update/libs</url>
     </repository>
     <repository>
       <id>orbit neon</id>
@@ -58,7 +58,7 @@
     <repository>
       <id>kernel</id>
       <layout>p2</layout>
-      <url>https://download.erlide.org/update/kernel/0.115.3</url>
+      <url>https://erlide.org/update/kernel/0.116.0</url>
     </repository>
   </repositories>
 
@@ -336,7 +336,7 @@
         <!--plugin> <groupId>org.eclipse.tycho</groupId> <artifactId>tycho-p2-plugin</artifactId>
           <version>${tycho.version}</version> <configuration> <baselineMode>failCommon</baselineMode>
           <baselineReplace>none</baselineReplace> <baselineRepositories> <repository>
-          <url>https://download.erlide.org/update/</url> </repository> </baselineRepositories>
+          <url>https://erlide.org/update/</url> </repository> </baselineRepositories>
           </configuration> </plugin -->
         <!--This plugin's configuration is used to store Eclipse m2e settings
           only. It has no influence on the Maven build itself. -->

--- a/releng/org.erlide.releng/setup/erlide.setup
+++ b/releng/org.erlide.releng/setup/erlide.setup
@@ -54,7 +54,7 @@
         name="org.eclipse.xtend.sdk.feature.group"
         versionRange="[2.8.3,2.9.0)"/>
     <repository
-        url="https://download.erlide.org/update"/>
+        url="https://erlide.org/update"/>
     <repository
         url="http://download.eclipse.org/modeling/tmf/xtext/updates/composite/releases/"/>
     <description>Install the tools needed in the IDE to work with the source code for ${scope.project.label}</description>

--- a/releng/org.erlide.site/category.xml
+++ b/releng/org.erlide.site/category.xml
@@ -7,7 +7,7 @@
       <category name="extras"/>
    </feature>
    <feature url="features/com.abstratt.eclipsegraphviz.feature_2.2.201606.201701211537.jar" id="com.abstratt.eclipsegraphviz.feature" version="2.2.201606.201701211537"/>
-   <feature url="features/org.erlide.kernel.feature_0.115.3.201806041948.jar" id="org.erlide.kernel.feature" version="0.115.3.201806041948">
+   <feature url="features/org.erlide.kernel.feature_0.116.0.202301241309.jar" id="org.erlide.kernel.feature" version="0.116.0.202301241309">
       <category name="erlide"/>
    </feature>
    <bundle id="com.google.guava"/>

--- a/releng/org.erlide.site/pom.xml
+++ b/releng/org.erlide.site/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.erlide</groupId>
     <artifactId>org.erlide.parent</artifactId>
-    <version>0.60.4-SNAPSHOT</version>
+    <version>0.61.0-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/releng/org.erlide.target/org.erlide.target.target
+++ b/releng/org.erlide.target/org.erlide.target.target
@@ -11,7 +11,7 @@
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="true" type="InstallableUnit">
       <unit id="com.abstratt.eclipsegraphviz.feature.feature.group" version="0.0.0"/>
-      <repository location="https://download.erlide.org/update/libs"/>
+      <repository location="https://erlide.org/update/libs"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="true" type="InstallableUnit">
       <unit id="org.eclipse.xtext.xbase.lib" version="0.0.0"/>
@@ -19,7 +19,7 @@
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="true" type="InstallableUnit">
       <unit id="org.erlide.kernel.feature.feature.group" version="0.0.0"/>
-      <repository location="https://download.erlide.org/update/kernel/0.115.3"/>
+      <repository location="https://erlide.org/update/kernel/0.116.0"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="true" type="InstallableUnit">
       <unit id="com.google.gson" version="2.8.2.v20180104-1110"/>

--- a/releng/org.erlide.target/org.erlide.target.tpd
+++ b/releng/org.erlide.target/org.erlide.target.tpd
@@ -9,7 +9,7 @@ location "http://download.eclipse.org/eclipse/updates/4.10/" {
   org.eclipse.jdt.annotation lazy
   org.eclipse.sdk.ide lazy
 }
-location "https://download.erlide.org/update/libs" {
+location "https://erlide.org/update/libs" {
   com.abstratt.eclipsegraphviz.feature.feature.group lazy //[2.2.0, 3.0.0)
 }
 
@@ -17,7 +17,7 @@ location "http://download.eclipse.org/modeling/tmf/xtext/updates/releases/2.19.0
   org.eclipse.xtext.xbase.lib lazy
 }
 
-location "https://download.erlide.org/update/kernel/0.115.3" {
+location "https://erlide.org/update/kernel/0.116.0" {
   org.erlide.kernel.feature.feature.group lazy
 }
 

--- a/releng/org.erlide.target/pom.xml
+++ b/releng/org.erlide.target/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <groupId>org.erlide</groupId>
     <artifactId>org.erlide.parent</artifactId>
-        <version>0.60.4-SNAPSHOT</version>
+        <version>0.61.0-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 
   <artifactId>org.erlide.target</artifactId>
-  <version>0.60.4-SNAPSHOT</version>
+  <version>0.61.0-SNAPSHOT</version>
   <packaging>eclipse-target-definition</packaging>
 </project>

--- a/tests/org.erlide.backend.tests/META-INF/MANIFEST.MF
+++ b/tests/org.erlide.backend.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Backend Tests
 Bundle-SymbolicName: org.erlide.backend.tests
-Bundle-Version: 0.60.4.qualifier
+Bundle-Version: 0.61.0.qualifier
 Bundle-Vendor: erlide.org
 Fragment-Host: org.erlide.backend;bundle-version="0.19.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/tests/org.erlide.backend.tests/pom.xml
+++ b/tests/org.erlide.backend.tests/pom.xml
@@ -7,12 +7,12 @@
 	<parent>
 		<groupId>org.erlide</groupId>
 		<artifactId>org.erlide.parent</artifactId>
-        <version>0.60.4-SNAPSHOT</version>
+        <version>0.61.0-SNAPSHOT</version>
 		<relativePath>../..</relativePath>
 	</parent>
 
 	<artifactId>org.erlide.backend.tests</artifactId>
-	<version>0.60.4-SNAPSHOT</version>
+	<version>0.61.0-SNAPSHOT</version>
 	<packaging>eclipse-test-plugin</packaging>
 
 	<build>

--- a/tests/org.erlide.backend.tests/src/org/erlide/backend/ErlangPluginsTest.java
+++ b/tests/org.erlide.backend.tests/src/org/erlide/backend/ErlangPluginsTest.java
@@ -26,18 +26,18 @@ public class ErlangPluginsTest {
     }
 
     @Test
-    public void debugger17IsAvailable() {
-        checkBundleForTwoEbinElements("org.erlide.kernel.debugger", "/ebin/17");
+    public void debugger23IsAvailable() {
+        checkBundleForTwoEbinElements("org.erlide.kernel.debugger", "/ebin/23");
     }
 
     @Test
-    public void debugger18IsAvailable() {
-        checkBundleForTwoEbinElements("org.erlide.kernel.debugger", "/ebin/18");
+    public void debugger24IsAvailable() {
+        checkBundleForTwoEbinElements("org.erlide.kernel.debugger", "/ebin/24");
     }
 
     @Test
-    public void debugger19IsAvailable() {
-        checkBundleForTwoEbinElements("org.erlide.kernel.debugger", "/ebin/19");
+    public void debugger25IsAvailable() {
+        checkBundleForTwoEbinElements("org.erlide.kernel.debugger", "/ebin/25");
     }
 
     private void checkBundleForTwoEbinElements(final String pluginId, final String path) {

--- a/tests/org.erlide.core.tests/META-INF/MANIFEST.MF
+++ b/tests/org.erlide.core.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: erlide core Tests Fragment
 Bundle-SymbolicName: org.erlide.core.tests;singleton:=true
-Bundle-Version: 0.60.4.qualifier
+Bundle-Version: 0.61.0.qualifier
 Bundle-Vendor: erlide.org
 Fragment-Host: org.erlide.core;bundle-version="0.14.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/tests/org.erlide.core.tests/pom.xml
+++ b/tests/org.erlide.core.tests/pom.xml
@@ -6,12 +6,12 @@
 	<parent>
 		<groupId>org.erlide</groupId>
 		<artifactId>org.erlide.parent</artifactId>
-		<version>0.60.4-SNAPSHOT</version>
+		<version>0.61.0-SNAPSHOT</version>
 		<relativePath>../..</relativePath>
 	</parent>
 
 	<artifactId>org.erlide.core.tests</artifactId>
-	<version>0.60.4-SNAPSHOT</version>
+	<version>0.61.0-SNAPSHOT</version>
 	<packaging>eclipse-test-plugin</packaging>
 
 	<build>

--- a/tests/org.erlide.core.tests/src/org/erlide/core/services/builder/BuildersTest.java
+++ b/tests/org.erlide.core.tests/src/org/erlide/core/services/builder/BuildersTest.java
@@ -123,7 +123,7 @@ public class BuildersTest {
         prj.refreshLocal(IResource.DEPTH_INFINITE, null);
         final IErlProject erlPrj = ErlideTestUtils.createErlProject(prj);
         final ErlangProjectProperties properties = erlPrj.getProperties();
-        final RuntimeVersion _runtimeVersion = new RuntimeVersion(18);
+        final RuntimeVersion _runtimeVersion = new RuntimeVersion(23);
         properties.setRequiredRuntimeVersion(_runtimeVersion);
         erlPrj.setProperties(properties);
         ExternalBuilder.DEBUG = true;

--- a/tests/org.erlide.model.tests/META-INF/MANIFEST.MF
+++ b/tests/org.erlide.model.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: erlide model Tests Fragment
 Bundle-SymbolicName: org.erlide.model.tests;singleton:=true
-Bundle-Version: 0.60.4.qualifier
+Bundle-Version: 0.61.0.qualifier
 Bundle-Vendor: erlide.org
 Fragment-Host: org.erlide.model
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/tests/org.erlide.model.tests/pom.xml
+++ b/tests/org.erlide.model.tests/pom.xml
@@ -7,12 +7,12 @@
 	<parent>
 		<groupId>org.erlide</groupId>
 		<artifactId>org.erlide.parent</artifactId>
-		<version>0.60.4-SNAPSHOT</version>
+		<version>0.61.0-SNAPSHOT</version>
 		<relativePath>../..</relativePath>
 	</parent>
 
 	<artifactId>org.erlide.model.tests</artifactId>
-	<version>0.60.4-SNAPSHOT</version>
+	<version>0.61.0-SNAPSHOT</version>
 	<packaging>eclipse-test-plugin</packaging>
 
 	<build>

--- a/tests/org.erlide.runtime.tests/META-INF/MANIFEST.MF
+++ b/tests/org.erlide.runtime.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: erlide.runtime Tests Fragment
 Bundle-SymbolicName: org.erlide.runtime.tests;singleton:=true
-Bundle-Version: 0.60.4.qualifier
+Bundle-Version: 0.61.0.qualifier
 Bundle-Vendor: erlide.org
 Fragment-Host: org.erlide.runtime;bundle-version="0.20.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/tests/org.erlide.runtime.tests/pom.xml
+++ b/tests/org.erlide.runtime.tests/pom.xml
@@ -7,12 +7,12 @@
 	<parent>
 		<groupId>org.erlide</groupId>
 		<artifactId>org.erlide.parent</artifactId>
-		<version>0.60.4-SNAPSHOT</version>
+		<version>0.61.0-SNAPSHOT</version>
 		<relativePath>../..</relativePath>
 	</parent>
 
 	<artifactId>org.erlide.runtime.tests</artifactId>
-	<version>0.60.4-SNAPSHOT</version>
+	<version>0.61.0-SNAPSHOT</version>
 	<packaging>eclipse-test-plugin</packaging>
 
 	<build>

--- a/tests/org.erlide.test_support.tests/META-INF/MANIFEST.MF
+++ b/tests/org.erlide.test_support.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Test Support tests
 Bundle-SymbolicName: org.erlide.test_support.tests
-Bundle-Version: 0.60.4.qualifier
+Bundle-Version: 0.61.0.qualifier
 Bundle-Vendor: erlide.org
 Fragment-Host: org.erlide.test_support
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/tests/org.erlide.test_support.tests/pom.xml
+++ b/tests/org.erlide.test_support.tests/pom.xml
@@ -6,12 +6,12 @@
 	<parent>
 		<groupId>org.erlide</groupId>
 		<artifactId>org.erlide.parent</artifactId>
-		<version>0.60.4-SNAPSHOT</version>
+		<version>0.61.0-SNAPSHOT</version>
 		<relativePath>../..</relativePath>
 	</parent>
 
 	<artifactId>org.erlide.test_support.tests</artifactId>
-	<version>0.60.4-SNAPSHOT</version>
+	<version>0.61.0-SNAPSHOT</version>
 	<packaging>eclipse-test-plugin</packaging>
 
 	<build>

--- a/tests/org.erlide.testing.libs/META-INF/MANIFEST.MF
+++ b/tests/org.erlide.testing.libs/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Testing Support Libraries
 Bundle-SymbolicName: org.erlide.testing.libs;singleton:=true
-Bundle-Version: 0.60.4.qualifier
+Bundle-Version: 0.61.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.10.0",
  org.eclipse.core.resources;bundle-version="3.9.1",

--- a/tests/org.erlide.testing.libs/pom.xml
+++ b/tests/org.erlide.testing.libs/pom.xml
@@ -6,12 +6,12 @@
 	<parent>
 		<groupId>org.erlide</groupId>
 		<artifactId>org.erlide.parent</artifactId>
-		<version>0.60.4-SNAPSHOT</version>
+		<version>0.61.0-SNAPSHOT</version>
 		<relativePath>../..</relativePath>
 	</parent>
 
 	<artifactId>org.erlide.testing.libs</artifactId>
-	<version>0.60.4-SNAPSHOT</version>
+	<version>0.61.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 </project>

--- a/tests/org.erlide.ui.tests/META-INF/MANIFEST.MF
+++ b/tests/org.erlide.ui.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests
 Bundle-SymbolicName: org.erlide.ui.tests;singleton:=true
-Bundle-Version: 0.60.4.qualifier
+Bundle-Version: 0.61.0.qualifier
 Bundle-Vendor: Erilde.org project
 Fragment-Host: org.erlide.ui
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/tests/org.erlide.ui.tests/pom.xml
+++ b/tests/org.erlide.ui.tests/pom.xml
@@ -5,12 +5,12 @@
   <parent>
     <groupId>org.erlide</groupId>
     <artifactId>org.erlide.parent</artifactId>
-        <version>0.60.4-SNAPSHOT</version>
+        <version>0.61.0-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 
   <artifactId>org.erlide.ui.tests</artifactId>
-  <version>0.60.4-SNAPSHOT</version>
+  <version>0.61.0-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
     <build>

--- a/tests/org.erlide.util.tests/META-INF/MANIFEST.MF
+++ b/tests/org.erlide.util.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Util Tests
 Bundle-SymbolicName: org.erlide.util.tests
-Bundle-Version: 0.60.4.qualifier
+Bundle-Version: 0.61.0.qualifier
 Bundle-Vendor: erlide.org
 Fragment-Host: org.erlide.util;bundle-version="0.19.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/tests/org.erlide.util.tests/pom.xml
+++ b/tests/org.erlide.util.tests/pom.xml
@@ -5,12 +5,12 @@
   <parent>
     <groupId>org.erlide</groupId>
     <artifactId>org.erlide.parent</artifactId>
-        <version>0.60.4-SNAPSHOT</version>
+        <version>0.61.0-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 
   <artifactId>org.erlide.util.tests</artifactId>
-  <version>0.60.4-SNAPSHOT</version>
+  <version>0.61.0-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
     <build>


### PR DESCRIPTION
Update `erlide_kernel` to the version that supports OTP23/24/25,
which were available via https://github.com/erlang/erlide_kernel/pull/20

This PR also includes a lift of jinterface to 1.13.1 from OTP 25.2
and corrections to enable CI again.