### PR TITLE
Dialyzer corrections

### DIFF
--- a/extras/org.erlide.licenses/pom.xml
+++ b/extras/org.erlide.licenses/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.erlide</groupId>
 		<artifactId>org.erlide.parent</artifactId>
-        <version>0.61.0-SNAPSHOT</version>
+        <version>0.61.1-SNAPSHOT</version>
 		<relativePath>../..</relativePath>
 	</parent>
 

--- a/extras/wrangler/pom.xml
+++ b/extras/wrangler/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.erlide</groupId>
 		<artifactId>org.erlide.parent</artifactId>
-        <version>0.61.0-SNAPSHOT</version>
+        <version>0.61.1-SNAPSHOT</version>
 		<relativePath>../..</relativePath>
 	</parent>
 

--- a/features/org.erlide/feature.xml
+++ b/features/org.erlide/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.erlide"
       label="Erlang language tools IDE"
-      version="0.61.0.qualifier"
+      version="0.61.1.qualifier"
       provider-name="%vendorName"
       plugin="org.erlide.branding"
       image="erlang-64.gif"

--- a/features/org.erlide/pom.xml
+++ b/features/org.erlide/pom.xml
@@ -7,12 +7,12 @@
 	<parent>
 		<groupId>org.erlide</groupId>
 		<artifactId>org.erlide.parent</artifactId>
-		<version>0.61.0-SNAPSHOT</version>
+		<version>0.61.1-SNAPSHOT</version>
 		<relativePath>../..</relativePath>
 	</parent>
 
 	<artifactId>org.erlide</artifactId>
-	<version>0.61.0-SNAPSHOT</version>
+	<version>0.61.1-SNAPSHOT</version>
 	<packaging>eclipse-feature</packaging>
 
 </project>

--- a/libs/com.google.truth/pom.xml
+++ b/libs/com.google.truth/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.erlide</groupId>
 		<artifactId>org.erlide.parent</artifactId>
-		<version>0.61.0-SNAPSHOT</version>
+		<version>0.61.1-SNAPSHOT</version>
 		<relativePath>../..</relativePath>
 	</parent>
 

--- a/libs/pom.xml
+++ b/libs/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.erlide</groupId>
     <artifactId>org.erlide.parent</artifactId>
-    <version>0.61.0-SNAPSHOT</version>
+    <version>0.61.1-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/plugins/org.erlide.backend/META-INF/MANIFEST.MF
+++ b/plugins/org.erlide.backend/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.erlide.backend;singleton:=true
-Bundle-Version: 0.61.0.qualifier
+Bundle-Version: 0.61.1.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/plugins/org.erlide.backend/pom.xml
+++ b/plugins/org.erlide.backend/pom.xml
@@ -6,12 +6,12 @@
 	<parent>
 		<groupId>org.erlide</groupId>
 		<artifactId>org.erlide.parent</artifactId>
-		<version>0.61.0-SNAPSHOT</version>
+		<version>0.61.1-SNAPSHOT</version>
 		<relativePath>../..</relativePath>
 	</parent>
 
 	<artifactId>org.erlide.backend</artifactId>
-	<version>0.61.0-SNAPSHOT</version>
+	<version>0.61.1-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 </project>

--- a/plugins/org.erlide.branding/META-INF/MANIFEST.MF
+++ b/plugins/org.erlide.branding/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: erlide - Erlang language tools
 Bundle-SymbolicName: org.erlide.branding;singleton:=true
-Bundle-Version: 0.61.0.qualifier
+Bundle-Version: 0.61.1.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.7.0",
  org.eclipse.ui.intro.universal;bundle-version="3.2.500",

--- a/plugins/org.erlide.branding/pom.xml
+++ b/plugins/org.erlide.branding/pom.xml
@@ -5,12 +5,12 @@
   <parent>
     <groupId>org.erlide</groupId>
     <artifactId>org.erlide.parent</artifactId>
-        <version>0.61.0-SNAPSHOT</version>
+        <version>0.61.1-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 
   <artifactId>org.erlide.branding</artifactId>
-  <version>0.61.0-SNAPSHOT</version>
+  <version>0.61.1-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
     <build>

--- a/plugins/org.erlide.core/META-INF/MANIFEST.MF
+++ b/plugins/org.erlide.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.erlide.core; singleton:=true
-Bundle-Version: 0.61.0.qualifier
+Bundle-Version: 0.61.1.qualifier
 Bundle-Activator: org.erlide.core.ErlangPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/plugins/org.erlide.core/pom.xml
+++ b/plugins/org.erlide.core/pom.xml
@@ -6,12 +6,12 @@
 	<parent>
 		<groupId>org.erlide</groupId>
 		<artifactId>org.erlide.parent</artifactId>
-		<version>0.61.0-SNAPSHOT</version>
+		<version>0.61.1-SNAPSHOT</version>
 		<relativePath>../..</relativePath>
 	</parent>
 
 	<artifactId>org.erlide.core</artifactId>
-	<version>0.61.0-SNAPSHOT</version>
+	<version>0.61.1-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 </project>

--- a/plugins/org.erlide.core/src/org/erlide/dialyzer/builder/DialyzerMarkerUtils.java
+++ b/plugins/org.erlide.core/src/org/erlide/dialyzer/builder/DialyzerMarkerUtils.java
@@ -38,7 +38,7 @@ public class DialyzerMarkerUtils {
             final OtpErlangTuple t = (OtpErlangTuple) result.elementAt(i);
             final OtpErlangTuple fileLine = (OtpErlangTuple) t.elementAt(1);
             final String filename = Util.stringValue(fileLine.elementAt(0));
-            final OtpErlangLong lineL = (OtpErlangLong) fileLine.elementAt(1);
+            final OtpErlangLong lineL = getWarningLocationLine(fileLine.elementAt(1));
             if (!filename.isEmpty()) {
                 int line = 1;
                 try {
@@ -59,6 +59,16 @@ public class DialyzerMarkerUtils {
                 DialyzerMarkerUtils.addDialyzerWarningMarker(model, filename, line, msg);
             }
         }
+    }
+
+    // Get the warning line independent of OTP used.
+    private static OtpErlangLong getWarningLocationLine(final Object location) {
+        if (location instanceof OtpErlangTuple) {
+            // '{Line, Column}' is default from OTP 24 (see OTP: PR-2664/OTP-16824)
+            OtpErlangTuple lineColumn = (OtpErlangTuple)location;
+            return (OtpErlangLong) lineColumn.elementAt(0);
+        }
+        return (OtpErlangLong) location;
     }
 
     public static void addDialyzerWarningMarker(final IErlElementLocator model,

--- a/plugins/org.erlide.core/src/org/erlide/dialyzer/builder/ErlideDialyze.java
+++ b/plugins/org.erlide.core/src/org/erlide/dialyzer/builder/ErlideDialyze.java
@@ -5,7 +5,6 @@ import java.util.List;
 
 import org.eclipse.core.runtime.IPath;
 import org.erlide.runtime.rpc.IOtpRpc;
-import org.erlide.runtime.rpc.IRpcResultCallback;
 import org.erlide.runtime.rpc.RpcException;
 import org.erlide.runtime.rpc.RpcFuture;
 import org.erlide.util.ErlLogger;
@@ -18,10 +17,6 @@ import com.google.common.collect.Lists;
 public class ErlideDialyze {
 
     private static final String ERLIDE_DIALYZE = "erlide_dialyze";
-    private static final int LONG_TIMEOUT = 60000;
-    // private static final int FILE_TIMEOUT = 20000;
-    // private static final int INCLUDE_TIMEOUT = 40000;
-    private static final int UPDATE_TIMEOUT = ErlideDialyze.LONG_TIMEOUT * 10;
 
     public static RpcFuture dialyze(final IOtpRpc backend, final Collection<String> files,
             final Collection<String> pltPaths, final Collection<IPath> includeDirs,
@@ -47,15 +42,5 @@ public class ErlideDialyze {
             ErlLogger.error(e);
         }
         return result;
-    }
-
-    public static OtpErlangObject checkPlt(final IOtpRpc backend, final String plt,
-            final List<String> ebinDirs) throws RpcException {
-        if (ebinDirs == null) {
-            return backend.call(ErlideDialyze.UPDATE_TIMEOUT,
-                    ErlideDialyze.ERLIDE_DIALYZE, "check_plt", "s", plt);
-        }
-        return backend.call(ErlideDialyze.UPDATE_TIMEOUT, ErlideDialyze.ERLIDE_DIALYZE,
-                "update_plt_with_additional_paths", "sls", plt, ebinDirs);
     }
 }

--- a/plugins/org.erlide.core/src/org/erlide/dialyzer/builder/ErlideDialyze.java
+++ b/plugins/org.erlide.core/src/org/erlide/dialyzer/builder/ErlideDialyze.java
@@ -58,11 +58,4 @@ public class ErlideDialyze {
         return backend.call(ErlideDialyze.UPDATE_TIMEOUT, ErlideDialyze.ERLIDE_DIALYZE,
                 "update_plt_with_additional_paths", "sls", plt, ebinDirs);
     }
-
-    public static void startCheckPlt(final IOtpRpc backend, final String plt,
-            final List<String> ebinDirs, final IRpcResultCallback callback)
-            throws RpcException {
-        backend.async_call_result(callback, ErlideDialyze.ERLIDE_DIALYZE,
-                "start_update_plt_with_additional_paths", "xsls", plt, ebinDirs);
-    }
 }

--- a/plugins/org.erlide.cover.api/META-INF/MANIFEST.MF
+++ b/plugins/org.erlide.cover.api/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Cover Interfaces
 Bundle-SymbolicName: org.erlide.cover.api;singleton:=true
-Bundle-Version: 0.61.0.qualifier
+Bundle-Version: 0.61.1.qualifier
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.core.resources,
  org.erlide.model.api,

--- a/plugins/org.erlide.cover.api/pom.xml
+++ b/plugins/org.erlide.cover.api/pom.xml
@@ -5,11 +5,11 @@
   <parent>
     <groupId>org.erlide</groupId>
     <artifactId>org.erlide.parent</artifactId>
-        <version>0.61.0-SNAPSHOT</version>
+        <version>0.61.1-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 
   <artifactId>org.erlide.cover.api</artifactId>
-  <version>0.61.0-SNAPSHOT</version>
+  <version>0.61.1-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/plugins/org.erlide.cover.core/META-INF/MANIFEST.MF
+++ b/plugins/org.erlide.cover.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Cover suport for ErlIde (Core plugin)
 Bundle-SymbolicName: org.erlide.cover.core;singleton:=true
-Bundle-Version: 0.61.0.qualifier
+Bundle-Version: 0.61.1.qualifier
 Bundle-Activator: org.erlide.cover.core.Activator
 Bundle-Vendor: Erlang Solutions
 Require-Bundle: org.eclipse.core.runtime,

--- a/plugins/org.erlide.cover.core/pom.xml
+++ b/plugins/org.erlide.cover.core/pom.xml
@@ -5,11 +5,11 @@
   <parent>
     <groupId>org.erlide</groupId>
     <artifactId>org.erlide.parent</artifactId>
-        <version>0.61.0-SNAPSHOT</version>
+        <version>0.61.1-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 
   <artifactId>org.erlide.cover.core</artifactId>
-  <version>0.61.0-SNAPSHOT</version>
+  <version>0.61.1-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/plugins/org.erlide.cover.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.erlide.cover.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Cover plugin UI
 Bundle-SymbolicName: org.erlide.cover.ui;singleton:=true
-Bundle-Version: 0.61.0.qualifier
+Bundle-Version: 0.61.1.qualifier
 Bundle-Activator: org.erlide.cover.ui.Activator
 Bundle-Vendor: Erlang Solutions
 Require-Bundle: org.eclipse.ui,

--- a/plugins/org.erlide.cover.ui/pom.xml
+++ b/plugins/org.erlide.cover.ui/pom.xml
@@ -5,12 +5,12 @@
   <parent>
     <groupId>org.erlide</groupId>
     <artifactId>org.erlide.parent</artifactId>
-        <version>0.61.0-SNAPSHOT</version>
+        <version>0.61.1-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 
   <artifactId>org.erlide.cover.ui</artifactId>
-  <version>0.61.0-SNAPSHOT</version>
+  <version>0.61.1-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
 </project>

--- a/plugins/org.erlide.help/META-INF/MANIFEST.MF
+++ b/plugins/org.erlide.help/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.erlide.help; singleton:=true
-Bundle-Version: 0.61.0.qualifier
+Bundle-Version: 0.61.1.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.help;bundle-version="[3.6.0,4.0.0)",

--- a/plugins/org.erlide.help/pom.xml
+++ b/plugins/org.erlide.help/pom.xml
@@ -6,12 +6,12 @@
 	<parent>
 		<groupId>org.erlide</groupId>
 		<artifactId>org.erlide.parent</artifactId>
-		<version>0.61.0-SNAPSHOT</version>
+		<version>0.61.1-SNAPSHOT</version>
 		<relativePath>../..</relativePath>
 	</parent>
 
 	<artifactId>org.erlide.help</artifactId>
-	<version>0.61.0-SNAPSHOT</version>
+	<version>0.61.1-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 	<profiles>

--- a/plugins/org.erlide.model.api/META-INF/MANIFEST.MF
+++ b/plugins/org.erlide.model.api/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: erlide engine api
 Bundle-SymbolicName: org.erlide.model.api;singleton:=true
-Bundle-Version: 0.61.0.qualifier
+Bundle-Version: 0.61.1.qualifier
 Bundle-Vendor: erlide.org
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.erlide.engine,

--- a/plugins/org.erlide.model.api/pom.xml
+++ b/plugins/org.erlide.model.api/pom.xml
@@ -6,12 +6,12 @@
 	<parent>
 		<groupId>org.erlide</groupId>
 		<artifactId>org.erlide.parent</artifactId>
-        <version>0.61.0-SNAPSHOT</version>
+        <version>0.61.1-SNAPSHOT</version>
 		<relativePath>../..</relativePath>
 	</parent>
 
 	<artifactId>org.erlide.model.api</artifactId>
-	<version>0.61.0-SNAPSHOT</version>
+	<version>0.61.1-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 </project>

--- a/plugins/org.erlide.model/META-INF/MANIFEST.MF
+++ b/plugins/org.erlide.model/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: erlide model
 Bundle-SymbolicName: org.erlide.model;singleton:=true
-Bundle-Version: 0.61.0.qualifier
+Bundle-Version: 0.61.1.qualifier
 Bundle-Vendor: erlide.org project
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.10.0",
  org.eclipse.core.resources;bundle-version="3.7.0",

--- a/plugins/org.erlide.model/pom.xml
+++ b/plugins/org.erlide.model/pom.xml
@@ -6,12 +6,12 @@
 	<parent>
 		<groupId>org.erlide</groupId>
 		<artifactId>org.erlide.parent</artifactId>
-        <version>0.61.0-SNAPSHOT</version>
+        <version>0.61.1-SNAPSHOT</version>
 		<relativePath>../..</relativePath>
 	</parent>
 
 	<artifactId>org.erlide.model</artifactId>
-	<version>0.61.0-SNAPSHOT</version>
+	<version>0.61.1-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
     <build>

--- a/plugins/org.erlide.runtime/META-INF/MANIFEST.MF
+++ b/plugins/org.erlide.runtime/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Erlang backend support (no eclipse dependencies)
 Bundle-SymbolicName: org.erlide.runtime;singleton:=true
-Bundle-Version: 0.61.0.qualifier
+Bundle-Version: 0.61.1.qualifier
 Bundle-Vendor: erlide.org
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.erlide.util,

--- a/plugins/org.erlide.runtime/pom.xml
+++ b/plugins/org.erlide.runtime/pom.xml
@@ -6,12 +6,12 @@
 	<parent>
 		<groupId>org.erlide</groupId>
 		<artifactId>org.erlide.parent</artifactId>
-		<version>0.61.0-SNAPSHOT</version>
+		<version>0.61.1-SNAPSHOT</version>
 		<relativePath>../..</relativePath>
 	</parent>
 
 	<artifactId>org.erlide.runtime</artifactId>
-	<version>0.61.0-SNAPSHOT</version>
+	<version>0.61.1-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 </project>

--- a/plugins/org.erlide.test_support/META-INF/MANIFEST.MF
+++ b/plugins/org.erlide.test_support/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Test frameworks support plug-in
 Bundle-SymbolicName: org.erlide.test_support;singleton:=true
-Bundle-Version: 0.61.0.qualifier
+Bundle-Version: 0.61.1.qualifier
 Bundle-Activator: org.erlide.test_support.Activator
 Bundle-Vendor: erlide.org
 Require-Bundle: org.eclipse.ui,

--- a/plugins/org.erlide.test_support/pom.xml
+++ b/plugins/org.erlide.test_support/pom.xml
@@ -6,11 +6,11 @@
 	<parent>
 		<groupId>org.erlide</groupId>
 		<artifactId>org.erlide.parent</artifactId>
-        <version>0.61.0-SNAPSHOT</version>
+        <version>0.61.1-SNAPSHOT</version>
 		<relativePath>../..</relativePath>
 	</parent>
 
 	<artifactId>org.erlide.test_support</artifactId>
-	<version>0.61.0-SNAPSHOT</version>
+	<version>0.61.1-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/plugins/org.erlide.tracing.core/META-INF/MANIFEST.MF
+++ b/plugins/org.erlide.tracing.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Erlang tracing for Erlide (java classes)
 Bundle-SymbolicName: org.erlide.tracing.core;singleton:=true
-Bundle-Version: 0.61.0.qualifier
+Bundle-Version: 0.61.1.qualifier
 Bundle-Activator: org.erlide.tracing.core.Activator
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.core.expressions;bundle-version="3.4.300",

--- a/plugins/org.erlide.tracing.core/pom.xml
+++ b/plugins/org.erlide.tracing.core/pom.xml
@@ -6,11 +6,11 @@
 	<parent>
 		<groupId>org.erlide</groupId>
 		<artifactId>org.erlide.parent</artifactId>
-        <version>0.61.0-SNAPSHOT</version>
+        <version>0.61.1-SNAPSHOT</version>
 		<relativePath>../..</relativePath>
 	</parent>
 
 	<artifactId>org.erlide.tracing.core</artifactId>
-	<version>0.61.0-SNAPSHOT</version>
+	<version>0.61.1-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/plugins/org.erlide.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.erlide.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.erlide.ui; singleton:=true
-Bundle-Version: 0.61.0.qualifier
+Bundle-Version: 0.61.1.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: org.erlide.ui.internal.ErlideUIPlugin
 Bundle-Vendor: %providerName

--- a/plugins/org.erlide.ui/plugin.xml
+++ b/plugins/org.erlide.ui/plugin.xml
@@ -2148,7 +2148,7 @@
    <extension
          point="org.eclipse.ui.preferencePages">
       <page
-            category="org.erlide.ui.preferences.compiler"
+            category="org.erlide.ui.preferences"
             class="org.erlide.dialyzer.ui.prefs.DialyzerPreferencePage"
             id="org.erlide.dialyzer.ui.builder"
             name="Dialyzer">

--- a/plugins/org.erlide.ui/pom.xml
+++ b/plugins/org.erlide.ui/pom.xml
@@ -6,12 +6,12 @@
 	<parent>
 		<groupId>org.erlide</groupId>
 		<artifactId>org.erlide.parent</artifactId>
-        <version>0.61.0-SNAPSHOT</version>
+        <version>0.61.1-SNAPSHOT</version>
 		<relativePath>../..</relativePath>
 	</parent>
 
 	<artifactId>org.erlide.ui</artifactId>
-	<version>0.61.0-SNAPSHOT</version>
+	<version>0.61.1-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 </project>

--- a/plugins/org.erlide.ui/src/org/erlide/dialyzer/ui/prefs/DialyzerPreferencePage.java
+++ b/plugins/org.erlide.ui/src/org/erlide/dialyzer/ui/prefs/DialyzerPreferencePage.java
@@ -259,7 +259,7 @@ public class DialyzerPreferencePage extends PropertyPage
         gd.horizontalSpan = 2;
         composite.setLayoutData(gd);
         final Label l = new Label(composite, SWT.NONE);
-        l.setText("PLT files (multiple PLTs require Erlang/OTP R14B01 or later)");
+        l.setText("PLT files");
         gd = new GridData();
         gd.horizontalSpan = 2;
         l.setLayoutData(gd);

--- a/plugins/org.erlide.util/META-INF/MANIFEST.MF
+++ b/plugins/org.erlide.util/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Common code, dependent on Eclipse
 Bundle-SymbolicName: org.erlide.util;singleton:=true
-Bundle-Version: 0.61.0.qualifier
+Bundle-Version: 0.61.1.qualifier
 Bundle-Vendor: erlide.org
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.core.resources,

--- a/plugins/org.erlide.util/pom.xml
+++ b/plugins/org.erlide.util/pom.xml
@@ -6,12 +6,12 @@
 	<parent>
 		<groupId>org.erlide</groupId>
 		<artifactId>org.erlide.parent</artifactId>
-        <version>0.61.0-SNAPSHOT</version>
+        <version>0.61.1-SNAPSHOT</version>
 		<relativePath>../..</relativePath>
 	</parent>
 
 	<artifactId>org.erlide.util</artifactId>
-	<version>0.61.0-SNAPSHOT</version>
+	<version>0.61.1-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
     <repository>
       <id>kernel</id>
       <layout>p2</layout>
-      <url>https://erlide.org/update/kernel/0.116.0</url>
+      <url>https://erlide.org/update/kernel/0.117.0</url>
     </repository>
   </repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>org.erlide</groupId>
   <artifactId>org.erlide.parent</artifactId>
-  <version>0.61.0-SNAPSHOT</version>
+  <version>0.61.1-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <properties>
@@ -244,7 +244,7 @@
               <artifact>
                 <groupId>org.erlide</groupId>
                 <artifactId>org.erlide.target</artifactId>
-                <version>0.61.0-SNAPSHOT</version>
+                <version>0.61.1-SNAPSHOT</version>
               </artifact>
             </target>
             <environments>

--- a/releng/org.erlide.site/category.xml
+++ b/releng/org.erlide.site/category.xml
@@ -7,7 +7,7 @@
       <category name="extras"/>
    </feature>
    <feature url="features/com.abstratt.eclipsegraphviz.feature_2.2.201606.201701211537.jar" id="com.abstratt.eclipsegraphviz.feature" version="2.2.201606.201701211537"/>
-   <feature url="features/org.erlide.kernel.feature_0.116.0.202301241309.jar" id="org.erlide.kernel.feature" version="0.116.0.202301241309">
+   <feature url="features/org.erlide.kernel.feature_0.117.0.202301301452.jar" id="org.erlide.kernel.feature" version="0.117.0.202301301452">
       <category name="erlide"/>
    </feature>
    <bundle id="com.google.guava"/>

--- a/releng/org.erlide.site/pom.xml
+++ b/releng/org.erlide.site/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.erlide</groupId>
     <artifactId>org.erlide.parent</artifactId>
-    <version>0.61.0-SNAPSHOT</version>
+    <version>0.61.1-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/releng/org.erlide.target/org.erlide.target.target
+++ b/releng/org.erlide.target/org.erlide.target.target
@@ -19,7 +19,7 @@
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="true" type="InstallableUnit">
       <unit id="org.erlide.kernel.feature.feature.group" version="0.0.0"/>
-      <repository location="https://erlide.org/update/kernel/0.116.0"/>
+      <repository location="https://erlide.org/update/kernel/0.117.0"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="true" type="InstallableUnit">
       <unit id="com.google.gson" version="2.8.2.v20180104-1110"/>

--- a/releng/org.erlide.target/org.erlide.target.tpd
+++ b/releng/org.erlide.target/org.erlide.target.tpd
@@ -17,7 +17,7 @@ location "http://download.eclipse.org/modeling/tmf/xtext/updates/releases/2.19.0
   org.eclipse.xtext.xbase.lib lazy
 }
 
-location "https://erlide.org/update/kernel/0.116.0" {
+location "https://erlide.org/update/kernel/0.117.0" {
   org.erlide.kernel.feature.feature.group lazy
 }
 

--- a/releng/org.erlide.target/pom.xml
+++ b/releng/org.erlide.target/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <groupId>org.erlide</groupId>
     <artifactId>org.erlide.parent</artifactId>
-        <version>0.61.0-SNAPSHOT</version>
+        <version>0.61.1-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 
   <artifactId>org.erlide.target</artifactId>
-  <version>0.61.0-SNAPSHOT</version>
+  <version>0.61.1-SNAPSHOT</version>
   <packaging>eclipse-target-definition</packaging>
 </project>

--- a/tests/org.erlide.backend.tests/META-INF/MANIFEST.MF
+++ b/tests/org.erlide.backend.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Backend Tests
 Bundle-SymbolicName: org.erlide.backend.tests
-Bundle-Version: 0.61.0.qualifier
+Bundle-Version: 0.61.1.qualifier
 Bundle-Vendor: erlide.org
 Fragment-Host: org.erlide.backend;bundle-version="0.19.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/tests/org.erlide.backend.tests/pom.xml
+++ b/tests/org.erlide.backend.tests/pom.xml
@@ -7,12 +7,12 @@
 	<parent>
 		<groupId>org.erlide</groupId>
 		<artifactId>org.erlide.parent</artifactId>
-        <version>0.61.0-SNAPSHOT</version>
+        <version>0.61.1-SNAPSHOT</version>
 		<relativePath>../..</relativePath>
 	</parent>
 
 	<artifactId>org.erlide.backend.tests</artifactId>
-	<version>0.61.0-SNAPSHOT</version>
+	<version>0.61.1-SNAPSHOT</version>
 	<packaging>eclipse-test-plugin</packaging>
 
 	<build>

--- a/tests/org.erlide.core.tests/META-INF/MANIFEST.MF
+++ b/tests/org.erlide.core.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: erlide core Tests Fragment
 Bundle-SymbolicName: org.erlide.core.tests;singleton:=true
-Bundle-Version: 0.61.0.qualifier
+Bundle-Version: 0.61.1.qualifier
 Bundle-Vendor: erlide.org
 Fragment-Host: org.erlide.core;bundle-version="0.14.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/tests/org.erlide.core.tests/pom.xml
+++ b/tests/org.erlide.core.tests/pom.xml
@@ -6,12 +6,12 @@
 	<parent>
 		<groupId>org.erlide</groupId>
 		<artifactId>org.erlide.parent</artifactId>
-		<version>0.61.0-SNAPSHOT</version>
+		<version>0.61.1-SNAPSHOT</version>
 		<relativePath>../..</relativePath>
 	</parent>
 
 	<artifactId>org.erlide.core.tests</artifactId>
-	<version>0.61.0-SNAPSHOT</version>
+	<version>0.61.1-SNAPSHOT</version>
 	<packaging>eclipse-test-plugin</packaging>
 
 	<build>

--- a/tests/org.erlide.model.tests/META-INF/MANIFEST.MF
+++ b/tests/org.erlide.model.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: erlide model Tests Fragment
 Bundle-SymbolicName: org.erlide.model.tests;singleton:=true
-Bundle-Version: 0.61.0.qualifier
+Bundle-Version: 0.61.1.qualifier
 Bundle-Vendor: erlide.org
 Fragment-Host: org.erlide.model
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/tests/org.erlide.model.tests/pom.xml
+++ b/tests/org.erlide.model.tests/pom.xml
@@ -7,12 +7,12 @@
 	<parent>
 		<groupId>org.erlide</groupId>
 		<artifactId>org.erlide.parent</artifactId>
-		<version>0.61.0-SNAPSHOT</version>
+		<version>0.61.1-SNAPSHOT</version>
 		<relativePath>../..</relativePath>
 	</parent>
 
 	<artifactId>org.erlide.model.tests</artifactId>
-	<version>0.61.0-SNAPSHOT</version>
+	<version>0.61.1-SNAPSHOT</version>
 	<packaging>eclipse-test-plugin</packaging>
 
 	<build>

--- a/tests/org.erlide.runtime.tests/META-INF/MANIFEST.MF
+++ b/tests/org.erlide.runtime.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: erlide.runtime Tests Fragment
 Bundle-SymbolicName: org.erlide.runtime.tests;singleton:=true
-Bundle-Version: 0.61.0.qualifier
+Bundle-Version: 0.61.1.qualifier
 Bundle-Vendor: erlide.org
 Fragment-Host: org.erlide.runtime;bundle-version="0.20.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/tests/org.erlide.runtime.tests/pom.xml
+++ b/tests/org.erlide.runtime.tests/pom.xml
@@ -7,12 +7,12 @@
 	<parent>
 		<groupId>org.erlide</groupId>
 		<artifactId>org.erlide.parent</artifactId>
-		<version>0.61.0-SNAPSHOT</version>
+		<version>0.61.1-SNAPSHOT</version>
 		<relativePath>../..</relativePath>
 	</parent>
 
 	<artifactId>org.erlide.runtime.tests</artifactId>
-	<version>0.61.0-SNAPSHOT</version>
+	<version>0.61.1-SNAPSHOT</version>
 	<packaging>eclipse-test-plugin</packaging>
 
 	<build>

--- a/tests/org.erlide.test_support.tests/META-INF/MANIFEST.MF
+++ b/tests/org.erlide.test_support.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Test Support tests
 Bundle-SymbolicName: org.erlide.test_support.tests
-Bundle-Version: 0.61.0.qualifier
+Bundle-Version: 0.61.1.qualifier
 Bundle-Vendor: erlide.org
 Fragment-Host: org.erlide.test_support
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/tests/org.erlide.test_support.tests/pom.xml
+++ b/tests/org.erlide.test_support.tests/pom.xml
@@ -6,12 +6,12 @@
 	<parent>
 		<groupId>org.erlide</groupId>
 		<artifactId>org.erlide.parent</artifactId>
-		<version>0.61.0-SNAPSHOT</version>
+		<version>0.61.1-SNAPSHOT</version>
 		<relativePath>../..</relativePath>
 	</parent>
 
 	<artifactId>org.erlide.test_support.tests</artifactId>
-	<version>0.61.0-SNAPSHOT</version>
+	<version>0.61.1-SNAPSHOT</version>
 	<packaging>eclipse-test-plugin</packaging>
 
 	<build>

--- a/tests/org.erlide.testing.libs/META-INF/MANIFEST.MF
+++ b/tests/org.erlide.testing.libs/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Testing Support Libraries
 Bundle-SymbolicName: org.erlide.testing.libs;singleton:=true
-Bundle-Version: 0.61.0.qualifier
+Bundle-Version: 0.61.1.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.10.0",
  org.eclipse.core.resources;bundle-version="3.9.1",

--- a/tests/org.erlide.testing.libs/pom.xml
+++ b/tests/org.erlide.testing.libs/pom.xml
@@ -6,12 +6,12 @@
 	<parent>
 		<groupId>org.erlide</groupId>
 		<artifactId>org.erlide.parent</artifactId>
-		<version>0.61.0-SNAPSHOT</version>
+		<version>0.61.1-SNAPSHOT</version>
 		<relativePath>../..</relativePath>
 	</parent>
 
 	<artifactId>org.erlide.testing.libs</artifactId>
-	<version>0.61.0-SNAPSHOT</version>
+	<version>0.61.1-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 </project>

--- a/tests/org.erlide.ui.tests/META-INF/MANIFEST.MF
+++ b/tests/org.erlide.ui.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests
 Bundle-SymbolicName: org.erlide.ui.tests;singleton:=true
-Bundle-Version: 0.61.0.qualifier
+Bundle-Version: 0.61.1.qualifier
 Bundle-Vendor: Erilde.org project
 Fragment-Host: org.erlide.ui
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/tests/org.erlide.ui.tests/pom.xml
+++ b/tests/org.erlide.ui.tests/pom.xml
@@ -5,12 +5,12 @@
   <parent>
     <groupId>org.erlide</groupId>
     <artifactId>org.erlide.parent</artifactId>
-        <version>0.61.0-SNAPSHOT</version>
+        <version>0.61.1-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 
   <artifactId>org.erlide.ui.tests</artifactId>
-  <version>0.61.0-SNAPSHOT</version>
+  <version>0.61.1-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
     <build>

--- a/tests/org.erlide.util.tests/META-INF/MANIFEST.MF
+++ b/tests/org.erlide.util.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Util Tests
 Bundle-SymbolicName: org.erlide.util.tests
-Bundle-Version: 0.61.0.qualifier
+Bundle-Version: 0.61.1.qualifier
 Bundle-Vendor: erlide.org
 Fragment-Host: org.erlide.util;bundle-version="0.19.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/tests/org.erlide.util.tests/pom.xml
+++ b/tests/org.erlide.util.tests/pom.xml
@@ -5,12 +5,12 @@
   <parent>
     <groupId>org.erlide</groupId>
     <artifactId>org.erlide.parent</artifactId>
-        <version>0.61.0-SNAPSHOT</version>
+        <version>0.61.1-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 
   <artifactId>org.erlide.util.tests</artifactId>
-  <version>0.61.0-SNAPSHOT</version>
+  <version>0.61.1-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
     <build>


### PR DESCRIPTION
This PR contains:
- Handle the new warning location format in OTP 24, see OTP [PR-2664](https://github.com/erlang/otp/commit/ee6a69bcef0dfdafe07906b939052d24e25be9c3) or OTP-16824.

- Removal of the "Update PLT" button in the Dialyzer preferences.
The button has had no effect since the configuration was removed in 2013 via commit [f5a52ab](https://github.com/erlang/erlide_eclipse/commit/f5a52ab)
A later commit [7545a0f](https://github.com/erlang/erlide_eclipse/commit/7545a0f), see [config](https://github.com/erlang/erlide_eclipse/blob/7545a0fb43b23b418b991a7cc9e0aaa0caf2ff18/org.erlide.ui/plugin.xml#L2184-L2192), only re-added the non project specific config which wont call erlide_kernel.

- Removal of an unused function `ErlideDialyze.startCheckPlt()`.

- Changed the Dialyzer preferences menu placement from `Erlang > Compiler > Dialyzer` to `Erlang > Dialyzer`

Matching PR: https://github.com/erlang/erlide_kernel/pull/23