### PR TITLE
Lift deprecated versions of CI actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,12 +7,13 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up JDK 1.8
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v4
       with:
         java-version: 8
-    - uses: actions/cache@v1
+        distribution: temurin
+    - uses: actions/cache@v4
       with:
         path: ~/.m2
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
@@ -23,12 +24,12 @@ jobs:
         otp-version: '23'
     - name: erl
       run: erl -version
-    - uses: actions/setup-ruby@v1
+    - uses: ruby/setup-ruby@v1
       with:
         ruby-version: '2.7'
     - name: Build with Maven
-      run: PATH=$PATH:/home/runner/.gem/ruby/2.7/bin xvfb-run ./mvnw -B -U clean verify -P help
-    - uses: actions/upload-artifact@v2
+      run: xvfb-run ./mvnw -B -U clean verify -P help
+    - uses: actions/upload-artifact@v4
       with:
         name: P2 site
         path: releng/org.erlide.site/target/repository


### PR DESCRIPTION
Since some versions of used actions are deprecated the CI wont run.
Lift versions of `actions/checkout`, `actions/cache`, `actions/setup-java` and start using recommended `ruby/setup-ruby` (which setup PATH correcly).