### PR TITLE
Update to support OTP25-27

### DIFF
--- a/extras/org.erlide.licenses/pom.xml
+++ b/extras/org.erlide.licenses/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.erlide</groupId>
 		<artifactId>org.erlide.parent</artifactId>
-        <version>0.62.0-SNAPSHOT</version>
+        <version>0.63.0-SNAPSHOT</version>
 		<relativePath>../..</relativePath>
 	</parent>
 

--- a/extras/wrangler/pom.xml
+++ b/extras/wrangler/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.erlide</groupId>
 		<artifactId>org.erlide.parent</artifactId>
-        <version>0.62.0-SNAPSHOT</version>
+        <version>0.63.0-SNAPSHOT</version>
 		<relativePath>../..</relativePath>
 	</parent>
 

--- a/features/org.erlide/feature.xml
+++ b/features/org.erlide/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.erlide"
       label="Erlang language tools IDE"
-      version="0.62.0.qualifier"
+      version="0.63.0.qualifier"
       provider-name="%vendorName"
       plugin="org.erlide.branding"
       image="erlang-64.gif"

--- a/features/org.erlide/pom.xml
+++ b/features/org.erlide/pom.xml
@@ -7,12 +7,12 @@
 	<parent>
 		<groupId>org.erlide</groupId>
 		<artifactId>org.erlide.parent</artifactId>
-		<version>0.62.0-SNAPSHOT</version>
+		<version>0.63.0-SNAPSHOT</version>
 		<relativePath>../..</relativePath>
 	</parent>
 
 	<artifactId>org.erlide</artifactId>
-	<version>0.62.0-SNAPSHOT</version>
+	<version>0.63.0-SNAPSHOT</version>
 	<packaging>eclipse-feature</packaging>
 
 </project>

--- a/libs/com.ericsson.otp.jinterface/META-INF/MANIFEST.MF
+++ b/libs/com.ericsson.otp.jinterface/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Erlang OTP JInterface
 Bundle-SymbolicName: com.ericsson.otp.jinterface
 Bundle-ActivationPolicy: lazy
-Bundle-Version: 1.13.1
+Bundle-Version: 1.14.1
 Bundle-Vendor: Erlide project
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: com.ericsson.otp.erlang

--- a/libs/com.ericsson.otp.jinterface/pom.xml
+++ b/libs/com.ericsson.otp.jinterface/pom.xml
@@ -11,7 +11,7 @@
 	</parent>
 
 	<artifactId>com.ericsson.otp.jinterface</artifactId>
-	<version>1.13.1</version>
+	<version>1.14.1</version>
 	<packaging>eclipse-plugin</packaging>
 
 	<build>

--- a/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/AbstractNode.java
+++ b/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/AbstractNode.java
@@ -111,9 +111,14 @@ public class AbstractNode implements OtpTransportFactory {
         | dFlagBitBinaries
         | dFlagHandshake23;
 
+    /* New mandatory flags in OTP 26 */
+    static final long mandatoryFlags26 = dFlagV4PidsRefs
+        | dFlagUnlinkId;
+    
     /* Mandatory flags for distribution. Keep them in sync with
        DFLAG_DIST_MANDATORY in erts/emulator/beam/dist.h. */
-    static final long mandatoryFlags = mandatoryFlags25;
+    static final long mandatoryFlags = mandatoryFlags25
+        | mandatoryFlags26;
 
     int ntype = NTYPE_R6;
     int proto = 0; // tcp/ip
@@ -121,8 +126,6 @@ public class AbstractNode implements OtpTransportFactory {
     int distLow = 6; // Cannot talk to nodes before OTP 23
     private int creation = 0x710000;
     long flags = mandatoryFlags
-        | dFlagUnlinkId
-        | dFlagV4PidsRefs
         | dFlagMandatory25Digest;
 
     /* initialize hostname and default cookie */

--- a/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/Makefile
+++ b/libs/com.ericsson.otp.jinterface/src/com/ericsson/otp/erlang/Makefile
@@ -3,7 +3,7 @@
 #
 # %CopyrightBegin%
 #
-# Copyright Ericsson AB 2000-2022. All Rights Reserved.
+# Copyright Ericsson AB 2000-2024. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -132,7 +132,5 @@ release_spec: opt
 	$(V_at)$(INSTALL_DATA) $(APPUP_TARGET) "$(RELSYSDIR)/ebin/$(APPUP_FILE)"
 
 release_docs_spec:
-
-xmllint:
 
 # ----------------------------------------------------

--- a/libs/com.google.truth/pom.xml
+++ b/libs/com.google.truth/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.erlide</groupId>
 		<artifactId>org.erlide.parent</artifactId>
-		<version>0.62.0-SNAPSHOT</version>
+		<version>0.63.0-SNAPSHOT</version>
 		<relativePath>../..</relativePath>
 	</parent>
 

--- a/libs/pom.xml
+++ b/libs/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.erlide</groupId>
     <artifactId>org.erlide.parent</artifactId>
-    <version>0.62.0-SNAPSHOT</version>
+    <version>0.63.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/plugins/org.erlide.backend/META-INF/MANIFEST.MF
+++ b/plugins/org.erlide.backend/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.erlide.backend;singleton:=true
-Bundle-Version: 0.62.0.qualifier
+Bundle-Version: 0.63.0.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/plugins/org.erlide.backend/pom.xml
+++ b/plugins/org.erlide.backend/pom.xml
@@ -6,12 +6,12 @@
 	<parent>
 		<groupId>org.erlide</groupId>
 		<artifactId>org.erlide.parent</artifactId>
-		<version>0.62.0-SNAPSHOT</version>
+		<version>0.63.0-SNAPSHOT</version>
 		<relativePath>../..</relativePath>
 	</parent>
 
 	<artifactId>org.erlide.backend</artifactId>
-	<version>0.62.0-SNAPSHOT</version>
+	<version>0.63.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 </project>

--- a/plugins/org.erlide.branding/META-INF/MANIFEST.MF
+++ b/plugins/org.erlide.branding/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: erlide - Erlang language tools
 Bundle-SymbolicName: org.erlide.branding;singleton:=true
-Bundle-Version: 0.62.0.qualifier
+Bundle-Version: 0.63.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.7.0",
  org.eclipse.ui.intro.universal;bundle-version="3.2.500",

--- a/plugins/org.erlide.branding/pom.xml
+++ b/plugins/org.erlide.branding/pom.xml
@@ -5,12 +5,12 @@
   <parent>
     <groupId>org.erlide</groupId>
     <artifactId>org.erlide.parent</artifactId>
-        <version>0.62.0-SNAPSHOT</version>
+        <version>0.63.0-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 
   <artifactId>org.erlide.branding</artifactId>
-  <version>0.62.0-SNAPSHOT</version>
+  <version>0.63.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
     <build>

--- a/plugins/org.erlide.core/META-INF/MANIFEST.MF
+++ b/plugins/org.erlide.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.erlide.core; singleton:=true
-Bundle-Version: 0.62.0.qualifier
+Bundle-Version: 0.63.0.qualifier
 Bundle-Activator: org.erlide.core.ErlangPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/plugins/org.erlide.core/pom.xml
+++ b/plugins/org.erlide.core/pom.xml
@@ -6,12 +6,12 @@
 	<parent>
 		<groupId>org.erlide</groupId>
 		<artifactId>org.erlide.parent</artifactId>
-		<version>0.62.0-SNAPSHOT</version>
+		<version>0.63.0-SNAPSHOT</version>
 		<relativePath>../..</relativePath>
 	</parent>
 
 	<artifactId>org.erlide.core</artifactId>
-	<version>0.62.0-SNAPSHOT</version>
+	<version>0.63.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 </project>

--- a/plugins/org.erlide.cover.api/META-INF/MANIFEST.MF
+++ b/plugins/org.erlide.cover.api/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Cover Interfaces
 Bundle-SymbolicName: org.erlide.cover.api;singleton:=true
-Bundle-Version: 0.62.0.qualifier
+Bundle-Version: 0.63.0.qualifier
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.core.resources,
  org.erlide.model.api,

--- a/plugins/org.erlide.cover.api/pom.xml
+++ b/plugins/org.erlide.cover.api/pom.xml
@@ -5,11 +5,11 @@
   <parent>
     <groupId>org.erlide</groupId>
     <artifactId>org.erlide.parent</artifactId>
-        <version>0.62.0-SNAPSHOT</version>
+        <version>0.63.0-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 
   <artifactId>org.erlide.cover.api</artifactId>
-  <version>0.62.0-SNAPSHOT</version>
+  <version>0.63.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/plugins/org.erlide.cover.core/META-INF/MANIFEST.MF
+++ b/plugins/org.erlide.cover.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Cover suport for ErlIde (Core plugin)
 Bundle-SymbolicName: org.erlide.cover.core;singleton:=true
-Bundle-Version: 0.62.0.qualifier
+Bundle-Version: 0.63.0.qualifier
 Bundle-Activator: org.erlide.cover.core.Activator
 Bundle-Vendor: Erlang Solutions
 Require-Bundle: org.eclipse.core.runtime,

--- a/plugins/org.erlide.cover.core/pom.xml
+++ b/plugins/org.erlide.cover.core/pom.xml
@@ -5,11 +5,11 @@
   <parent>
     <groupId>org.erlide</groupId>
     <artifactId>org.erlide.parent</artifactId>
-        <version>0.62.0-SNAPSHOT</version>
+        <version>0.63.0-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 
   <artifactId>org.erlide.cover.core</artifactId>
-  <version>0.62.0-SNAPSHOT</version>
+  <version>0.63.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/plugins/org.erlide.cover.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.erlide.cover.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Cover plugin UI
 Bundle-SymbolicName: org.erlide.cover.ui;singleton:=true
-Bundle-Version: 0.62.0.qualifier
+Bundle-Version: 0.63.0.qualifier
 Bundle-Activator: org.erlide.cover.ui.Activator
 Bundle-Vendor: Erlang Solutions
 Require-Bundle: org.eclipse.ui,

--- a/plugins/org.erlide.cover.ui/pom.xml
+++ b/plugins/org.erlide.cover.ui/pom.xml
@@ -5,12 +5,12 @@
   <parent>
     <groupId>org.erlide</groupId>
     <artifactId>org.erlide.parent</artifactId>
-        <version>0.62.0-SNAPSHOT</version>
+        <version>0.63.0-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 
   <artifactId>org.erlide.cover.ui</artifactId>
-  <version>0.62.0-SNAPSHOT</version>
+  <version>0.63.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
 </project>

--- a/plugins/org.erlide.help/META-INF/MANIFEST.MF
+++ b/plugins/org.erlide.help/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.erlide.help; singleton:=true
-Bundle-Version: 0.62.0.qualifier
+Bundle-Version: 0.63.0.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.help;bundle-version="[3.6.0,4.0.0)",

--- a/plugins/org.erlide.help/articles/eclipse/120_Installing-and-updating.md
+++ b/plugins/org.erlide.help/articles/eclipse/120_Installing-and-updating.md
@@ -6,7 +6,7 @@ part: Getting started
 
 # Installing and updating
 
-* Install a supported Erlang version like __Erlang/OTP 23__, if it isn't already present on your system. On Windows systems, use a path with no spaces in it.
+* Install a supported Erlang version like __Erlang/OTP 25__, if it isn't already present on your system. On Windows systems, use a path with no spaces in it.
 * Java 8 is required.
 * Install Eclipse. ErlIDE is confirmed to be compatible with `Eclipse 2024-06` and earlier.
 * If your network uses a proxy to connect to the internet, fill in the appropriate data in `Window -> Preferences -> General -> Network connections`

--- a/plugins/org.erlide.help/pom.xml
+++ b/plugins/org.erlide.help/pom.xml
@@ -6,12 +6,12 @@
 	<parent>
 		<groupId>org.erlide</groupId>
 		<artifactId>org.erlide.parent</artifactId>
-		<version>0.62.0-SNAPSHOT</version>
+		<version>0.63.0-SNAPSHOT</version>
 		<relativePath>../..</relativePath>
 	</parent>
 
 	<artifactId>org.erlide.help</artifactId>
-	<version>0.62.0-SNAPSHOT</version>
+	<version>0.63.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 	<profiles>

--- a/plugins/org.erlide.model.api/META-INF/MANIFEST.MF
+++ b/plugins/org.erlide.model.api/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: erlide engine api
 Bundle-SymbolicName: org.erlide.model.api;singleton:=true
-Bundle-Version: 0.62.0.qualifier
+Bundle-Version: 0.63.0.qualifier
 Bundle-Vendor: erlide.org
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.erlide.engine,

--- a/plugins/org.erlide.model.api/pom.xml
+++ b/plugins/org.erlide.model.api/pom.xml
@@ -6,12 +6,12 @@
 	<parent>
 		<groupId>org.erlide</groupId>
 		<artifactId>org.erlide.parent</artifactId>
-        <version>0.62.0-SNAPSHOT</version>
+        <version>0.63.0-SNAPSHOT</version>
 		<relativePath>../..</relativePath>
 	</parent>
 
 	<artifactId>org.erlide.model.api</artifactId>
-	<version>0.62.0-SNAPSHOT</version>
+	<version>0.63.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 </project>

--- a/plugins/org.erlide.model.api/src/org/erlide/engine/model/root/ProjectPreferencesConstants.java
+++ b/plugins/org.erlide.model.api/src/org/erlide/engine/model/root/ProjectPreferencesConstants.java
@@ -33,9 +33,9 @@ public final class ProjectPreferencesConstants {
     public static final String DEFAULT_EXTERNAL_INCLUDES = "";
 
     public static final String RUNTIME_VERSION = "backend_version";
-    public static final RuntimeVersion DEFAULT_RUNTIME_VERSION = new RuntimeVersion(23);
-    public static final RuntimeVersion[] SUPPORTED_VERSIONS = { new RuntimeVersion(23),
-            new RuntimeVersion(24), new RuntimeVersion(25) };
+    public static final RuntimeVersion DEFAULT_RUNTIME_VERSION = new RuntimeVersion(25);
+    public static final RuntimeVersion[] SUPPORTED_VERSIONS = { new RuntimeVersion(25),
+            new RuntimeVersion(26), new RuntimeVersion(27) };
     public static final RuntimeVersion FALLBACK_RUNTIME_VERSION = ProjectPreferencesConstants.SUPPORTED_VERSIONS[0];
 
     public static final String PROJECT_EXTERNAL_MODULES = "external_modules";

--- a/plugins/org.erlide.model/META-INF/MANIFEST.MF
+++ b/plugins/org.erlide.model/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: erlide model
 Bundle-SymbolicName: org.erlide.model;singleton:=true
-Bundle-Version: 0.62.0.qualifier
+Bundle-Version: 0.63.0.qualifier
 Bundle-Vendor: erlide.org project
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.10.0",
  org.eclipse.core.resources;bundle-version="3.7.0",

--- a/plugins/org.erlide.model/pom.xml
+++ b/plugins/org.erlide.model/pom.xml
@@ -6,12 +6,12 @@
 	<parent>
 		<groupId>org.erlide</groupId>
 		<artifactId>org.erlide.parent</artifactId>
-        <version>0.62.0-SNAPSHOT</version>
+        <version>0.63.0-SNAPSHOT</version>
 		<relativePath>../..</relativePath>
 	</parent>
 
 	<artifactId>org.erlide.model</artifactId>
-	<version>0.62.0-SNAPSHOT</version>
+	<version>0.63.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
     <build>

--- a/plugins/org.erlide.runtime/META-INF/MANIFEST.MF
+++ b/plugins/org.erlide.runtime/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Erlang backend support (no eclipse dependencies)
 Bundle-SymbolicName: org.erlide.runtime;singleton:=true
-Bundle-Version: 0.62.0.qualifier
+Bundle-Version: 0.63.0.qualifier
 Bundle-Vendor: erlide.org
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.erlide.util,

--- a/plugins/org.erlide.runtime/pom.xml
+++ b/plugins/org.erlide.runtime/pom.xml
@@ -6,12 +6,12 @@
 	<parent>
 		<groupId>org.erlide</groupId>
 		<artifactId>org.erlide.parent</artifactId>
-		<version>0.62.0-SNAPSHOT</version>
+		<version>0.63.0-SNAPSHOT</version>
 		<relativePath>../..</relativePath>
 	</parent>
 
 	<artifactId>org.erlide.runtime</artifactId>
-	<version>0.62.0-SNAPSHOT</version>
+	<version>0.63.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 </project>

--- a/plugins/org.erlide.runtime/src/org/erlide/runtime/runtimeinfo/IRuntimeInfoCatalog.java
+++ b/plugins/org.erlide.runtime/src/org/erlide/runtime/runtimeinfo/IRuntimeInfoCatalog.java
@@ -5,7 +5,7 @@ import java.util.List;
 
 public interface IRuntimeInfoCatalog {
 
-    RuntimeVersion OLDEST_SUPPORTED_VERSION = new RuntimeVersion(23);
+    RuntimeVersion OLDEST_SUPPORTED_VERSION = new RuntimeVersion(25);
 
     Collection<RuntimeInfo> getRuntimes();
 

--- a/plugins/org.erlide.test_support/META-INF/MANIFEST.MF
+++ b/plugins/org.erlide.test_support/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Test frameworks support plug-in
 Bundle-SymbolicName: org.erlide.test_support;singleton:=true
-Bundle-Version: 0.62.0.qualifier
+Bundle-Version: 0.63.0.qualifier
 Bundle-Activator: org.erlide.test_support.Activator
 Bundle-Vendor: erlide.org
 Require-Bundle: org.eclipse.ui,

--- a/plugins/org.erlide.test_support/pom.xml
+++ b/plugins/org.erlide.test_support/pom.xml
@@ -6,11 +6,11 @@
 	<parent>
 		<groupId>org.erlide</groupId>
 		<artifactId>org.erlide.parent</artifactId>
-        <version>0.62.0-SNAPSHOT</version>
+        <version>0.63.0-SNAPSHOT</version>
 		<relativePath>../..</relativePath>
 	</parent>
 
 	<artifactId>org.erlide.test_support</artifactId>
-	<version>0.62.0-SNAPSHOT</version>
+	<version>0.63.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/plugins/org.erlide.tracing.core/META-INF/MANIFEST.MF
+++ b/plugins/org.erlide.tracing.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Erlang tracing for Erlide (java classes)
 Bundle-SymbolicName: org.erlide.tracing.core;singleton:=true
-Bundle-Version: 0.62.0.qualifier
+Bundle-Version: 0.63.0.qualifier
 Bundle-Activator: org.erlide.tracing.core.Activator
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.core.expressions;bundle-version="3.4.300",

--- a/plugins/org.erlide.tracing.core/pom.xml
+++ b/plugins/org.erlide.tracing.core/pom.xml
@@ -6,11 +6,11 @@
 	<parent>
 		<groupId>org.erlide</groupId>
 		<artifactId>org.erlide.parent</artifactId>
-        <version>0.62.0-SNAPSHOT</version>
+        <version>0.63.0-SNAPSHOT</version>
 		<relativePath>../..</relativePath>
 	</parent>
 
 	<artifactId>org.erlide.tracing.core</artifactId>
-	<version>0.62.0-SNAPSHOT</version>
+	<version>0.63.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 </project>

--- a/plugins/org.erlide.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.erlide.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.erlide.ui; singleton:=true
-Bundle-Version: 0.62.0.qualifier
+Bundle-Version: 0.63.0.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: org.erlide.ui.internal.ErlideUIPlugin
 Bundle-Vendor: %providerName

--- a/plugins/org.erlide.ui/pom.xml
+++ b/plugins/org.erlide.ui/pom.xml
@@ -6,12 +6,12 @@
 	<parent>
 		<groupId>org.erlide</groupId>
 		<artifactId>org.erlide.parent</artifactId>
-        <version>0.62.0-SNAPSHOT</version>
+        <version>0.63.0-SNAPSHOT</version>
 		<relativePath>../..</relativePath>
 	</parent>
 
 	<artifactId>org.erlide.ui</artifactId>
-	<version>0.62.0-SNAPSHOT</version>
+	<version>0.63.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 </project>

--- a/plugins/org.erlide.util/META-INF/MANIFEST.MF
+++ b/plugins/org.erlide.util/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Common code, dependent on Eclipse
 Bundle-SymbolicName: org.erlide.util;singleton:=true
-Bundle-Version: 0.62.0.qualifier
+Bundle-Version: 0.63.0.qualifier
 Bundle-Vendor: erlide.org
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.core.resources,

--- a/plugins/org.erlide.util/pom.xml
+++ b/plugins/org.erlide.util/pom.xml
@@ -6,12 +6,12 @@
 	<parent>
 		<groupId>org.erlide</groupId>
 		<artifactId>org.erlide.parent</artifactId>
-        <version>0.62.0-SNAPSHOT</version>
+        <version>0.63.0-SNAPSHOT</version>
 		<relativePath>../..</relativePath>
 	</parent>
 
 	<artifactId>org.erlide.util</artifactId>
-	<version>0.62.0-SNAPSHOT</version>
+	<version>0.63.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
     <repository>
       <id>kernel</id>
       <layout>p2</layout>
-      <url>https://erlide.org/update/kernel/0.117.0</url>
+      <url>https://erlide.org/update/kernel/0.118.0</url>
     </repository>
   </repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>org.erlide</groupId>
   <artifactId>org.erlide.parent</artifactId>
-  <version>0.62.0-SNAPSHOT</version>
+  <version>0.63.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <properties>
@@ -244,7 +244,7 @@
               <artifact>
                 <groupId>org.erlide</groupId>
                 <artifactId>org.erlide.target</artifactId>
-                <version>0.62.0-SNAPSHOT</version>
+                <version>0.63.0-SNAPSHOT</version>
               </artifact>
             </target>
             <environments>

--- a/releng/org.erlide.site/category.xml
+++ b/releng/org.erlide.site/category.xml
@@ -7,7 +7,7 @@
       <category name="extras"/>
    </feature>
    <feature url="features/com.abstratt.eclipsegraphviz.feature_2.2.201606.201701211537.jar" id="com.abstratt.eclipsegraphviz.feature" version="2.2.201606.201701211537"/>
-   <feature url="features/org.erlide.kernel.feature_0.117.0.202301301452.jar" id="org.erlide.kernel.feature" version="0.117.0.202301301452">
+   <feature url="features/org.erlide.kernel.feature_0.118.0.202505270947.jar" id="org.erlide.kernel.feature" version="0.118.0.202505270947">
       <category name="erlide"/>
    </feature>
    <bundle id="com.google.guava"/>

--- a/releng/org.erlide.site/pom.xml
+++ b/releng/org.erlide.site/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.erlide</groupId>
     <artifactId>org.erlide.parent</artifactId>
-    <version>0.62.0-SNAPSHOT</version>
+    <version>0.63.0-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/releng/org.erlide.target/org.erlide.target.target
+++ b/releng/org.erlide.target/org.erlide.target.target
@@ -19,7 +19,7 @@
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="true" type="InstallableUnit">
       <unit id="org.erlide.kernel.feature.feature.group" version="0.0.0"/>
-      <repository location="https://erlide.org/update/kernel/0.117.0"/>
+      <repository location="https://erlide.org/update/kernel/0.118.0"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="true" type="InstallableUnit">
       <unit id="com.google.gson" version="2.8.2.v20180104-1110"/>

--- a/releng/org.erlide.target/org.erlide.target.tpd
+++ b/releng/org.erlide.target/org.erlide.target.tpd
@@ -17,7 +17,7 @@ location "http://download.eclipse.org/modeling/tmf/xtext/updates/releases/2.19.0
   org.eclipse.xtext.xbase.lib lazy
 }
 
-location "https://erlide.org/update/kernel/0.117.0" {
+location "https://erlide.org/update/kernel/0.118.0" {
   org.erlide.kernel.feature.feature.group lazy
 }
 

--- a/releng/org.erlide.target/pom.xml
+++ b/releng/org.erlide.target/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <groupId>org.erlide</groupId>
     <artifactId>org.erlide.parent</artifactId>
-        <version>0.62.0-SNAPSHOT</version>
+        <version>0.63.0-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 
   <artifactId>org.erlide.target</artifactId>
-  <version>0.62.0-SNAPSHOT</version>
+  <version>0.63.0-SNAPSHOT</version>
   <packaging>eclipse-target-definition</packaging>
 </project>

--- a/tests/org.erlide.backend.tests/META-INF/MANIFEST.MF
+++ b/tests/org.erlide.backend.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Backend Tests
 Bundle-SymbolicName: org.erlide.backend.tests
-Bundle-Version: 0.62.0.qualifier
+Bundle-Version: 0.63.0.qualifier
 Bundle-Vendor: erlide.org
 Fragment-Host: org.erlide.backend;bundle-version="0.19.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/tests/org.erlide.backend.tests/pom.xml
+++ b/tests/org.erlide.backend.tests/pom.xml
@@ -7,12 +7,12 @@
 	<parent>
 		<groupId>org.erlide</groupId>
 		<artifactId>org.erlide.parent</artifactId>
-        <version>0.62.0-SNAPSHOT</version>
+        <version>0.63.0-SNAPSHOT</version>
 		<relativePath>../..</relativePath>
 	</parent>
 
 	<artifactId>org.erlide.backend.tests</artifactId>
-	<version>0.62.0-SNAPSHOT</version>
+	<version>0.63.0-SNAPSHOT</version>
 	<packaging>eclipse-test-plugin</packaging>
 
 	<build>

--- a/tests/org.erlide.backend.tests/src/org/erlide/backend/ErlangPluginsTest.java
+++ b/tests/org.erlide.backend.tests/src/org/erlide/backend/ErlangPluginsTest.java
@@ -26,18 +26,18 @@ public class ErlangPluginsTest {
     }
 
     @Test
-    public void debugger23IsAvailable() {
-        checkBundleForTwoEbinElements("org.erlide.kernel.debugger", "/ebin/23");
-    }
-
-    @Test
-    public void debugger24IsAvailable() {
-        checkBundleForTwoEbinElements("org.erlide.kernel.debugger", "/ebin/24");
-    }
-
-    @Test
     public void debugger25IsAvailable() {
         checkBundleForTwoEbinElements("org.erlide.kernel.debugger", "/ebin/25");
+    }
+
+    @Test
+    public void debugger26IsAvailable() {
+        checkBundleForTwoEbinElements("org.erlide.kernel.debugger", "/ebin/26");
+    }
+
+    @Test
+    public void debugger27IsAvailable() {
+        checkBundleForTwoEbinElements("org.erlide.kernel.debugger", "/ebin/27");
     }
 
     private void checkBundleForTwoEbinElements(final String pluginId, final String path) {

--- a/tests/org.erlide.core.tests/META-INF/MANIFEST.MF
+++ b/tests/org.erlide.core.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: erlide core Tests Fragment
 Bundle-SymbolicName: org.erlide.core.tests;singleton:=true
-Bundle-Version: 0.62.0.qualifier
+Bundle-Version: 0.63.0.qualifier
 Bundle-Vendor: erlide.org
 Fragment-Host: org.erlide.core;bundle-version="0.14.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/tests/org.erlide.core.tests/pom.xml
+++ b/tests/org.erlide.core.tests/pom.xml
@@ -6,12 +6,12 @@
 	<parent>
 		<groupId>org.erlide</groupId>
 		<artifactId>org.erlide.parent</artifactId>
-		<version>0.62.0-SNAPSHOT</version>
+		<version>0.63.0-SNAPSHOT</version>
 		<relativePath>../..</relativePath>
 	</parent>
 
 	<artifactId>org.erlide.core.tests</artifactId>
-	<version>0.62.0-SNAPSHOT</version>
+	<version>0.63.0-SNAPSHOT</version>
 	<packaging>eclipse-test-plugin</packaging>
 
 	<build>

--- a/tests/org.erlide.core.tests/src/org/erlide/core/services/builder/BuildersTest.java
+++ b/tests/org.erlide.core.tests/src/org/erlide/core/services/builder/BuildersTest.java
@@ -123,7 +123,7 @@ public class BuildersTest {
         prj.refreshLocal(IResource.DEPTH_INFINITE, null);
         final IErlProject erlPrj = ErlideTestUtils.createErlProject(prj);
         final ErlangProjectProperties properties = erlPrj.getProperties();
-        final RuntimeVersion _runtimeVersion = new RuntimeVersion(23);
+        final RuntimeVersion _runtimeVersion = new RuntimeVersion(25);
         properties.setRequiredRuntimeVersion(_runtimeVersion);
         erlPrj.setProperties(properties);
         ExternalBuilder.DEBUG = true;

--- a/tests/org.erlide.model.tests/META-INF/MANIFEST.MF
+++ b/tests/org.erlide.model.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: erlide model Tests Fragment
 Bundle-SymbolicName: org.erlide.model.tests;singleton:=true
-Bundle-Version: 0.62.0.qualifier
+Bundle-Version: 0.63.0.qualifier
 Bundle-Vendor: erlide.org
 Fragment-Host: org.erlide.model
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/tests/org.erlide.model.tests/pom.xml
+++ b/tests/org.erlide.model.tests/pom.xml
@@ -7,12 +7,12 @@
 	<parent>
 		<groupId>org.erlide</groupId>
 		<artifactId>org.erlide.parent</artifactId>
-		<version>0.62.0-SNAPSHOT</version>
+		<version>0.63.0-SNAPSHOT</version>
 		<relativePath>../..</relativePath>
 	</parent>
 
 	<artifactId>org.erlide.model.tests</artifactId>
-	<version>0.62.0-SNAPSHOT</version>
+	<version>0.63.0-SNAPSHOT</version>
 	<packaging>eclipse-test-plugin</packaging>
 
 	<build>

--- a/tests/org.erlide.runtime.tests/META-INF/MANIFEST.MF
+++ b/tests/org.erlide.runtime.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: erlide.runtime Tests Fragment
 Bundle-SymbolicName: org.erlide.runtime.tests;singleton:=true
-Bundle-Version: 0.62.0.qualifier
+Bundle-Version: 0.63.0.qualifier
 Bundle-Vendor: erlide.org
 Fragment-Host: org.erlide.runtime;bundle-version="0.20.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/tests/org.erlide.runtime.tests/pom.xml
+++ b/tests/org.erlide.runtime.tests/pom.xml
@@ -7,12 +7,12 @@
 	<parent>
 		<groupId>org.erlide</groupId>
 		<artifactId>org.erlide.parent</artifactId>
-		<version>0.62.0-SNAPSHOT</version>
+		<version>0.63.0-SNAPSHOT</version>
 		<relativePath>../..</relativePath>
 	</parent>
 
 	<artifactId>org.erlide.runtime.tests</artifactId>
-	<version>0.62.0-SNAPSHOT</version>
+	<version>0.63.0-SNAPSHOT</version>
 	<packaging>eclipse-test-plugin</packaging>
 
 	<build>

--- a/tests/org.erlide.test_support.tests/META-INF/MANIFEST.MF
+++ b/tests/org.erlide.test_support.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Test Support tests
 Bundle-SymbolicName: org.erlide.test_support.tests
-Bundle-Version: 0.62.0.qualifier
+Bundle-Version: 0.63.0.qualifier
 Bundle-Vendor: erlide.org
 Fragment-Host: org.erlide.test_support
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/tests/org.erlide.test_support.tests/pom.xml
+++ b/tests/org.erlide.test_support.tests/pom.xml
@@ -6,12 +6,12 @@
 	<parent>
 		<groupId>org.erlide</groupId>
 		<artifactId>org.erlide.parent</artifactId>
-		<version>0.62.0-SNAPSHOT</version>
+		<version>0.63.0-SNAPSHOT</version>
 		<relativePath>../..</relativePath>
 	</parent>
 
 	<artifactId>org.erlide.test_support.tests</artifactId>
-	<version>0.62.0-SNAPSHOT</version>
+	<version>0.63.0-SNAPSHOT</version>
 	<packaging>eclipse-test-plugin</packaging>
 
 	<build>

--- a/tests/org.erlide.testing.libs/META-INF/MANIFEST.MF
+++ b/tests/org.erlide.testing.libs/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Testing Support Libraries
 Bundle-SymbolicName: org.erlide.testing.libs;singleton:=true
-Bundle-Version: 0.62.0.qualifier
+Bundle-Version: 0.63.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.10.0",
  org.eclipse.core.resources;bundle-version="3.9.1",

--- a/tests/org.erlide.testing.libs/pom.xml
+++ b/tests/org.erlide.testing.libs/pom.xml
@@ -6,12 +6,12 @@
 	<parent>
 		<groupId>org.erlide</groupId>
 		<artifactId>org.erlide.parent</artifactId>
-		<version>0.62.0-SNAPSHOT</version>
+		<version>0.63.0-SNAPSHOT</version>
 		<relativePath>../..</relativePath>
 	</parent>
 
 	<artifactId>org.erlide.testing.libs</artifactId>
-	<version>0.62.0-SNAPSHOT</version>
+	<version>0.63.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 </project>

--- a/tests/org.erlide.ui.tests/META-INF/MANIFEST.MF
+++ b/tests/org.erlide.ui.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests
 Bundle-SymbolicName: org.erlide.ui.tests;singleton:=true
-Bundle-Version: 0.62.0.qualifier
+Bundle-Version: 0.63.0.qualifier
 Bundle-Vendor: Erilde.org project
 Fragment-Host: org.erlide.ui
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/tests/org.erlide.ui.tests/pom.xml
+++ b/tests/org.erlide.ui.tests/pom.xml
@@ -5,12 +5,12 @@
   <parent>
     <groupId>org.erlide</groupId>
     <artifactId>org.erlide.parent</artifactId>
-        <version>0.62.0-SNAPSHOT</version>
+        <version>0.63.0-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 
   <artifactId>org.erlide.ui.tests</artifactId>
-  <version>0.62.0-SNAPSHOT</version>
+  <version>0.63.0-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
     <build>

--- a/tests/org.erlide.util.tests/META-INF/MANIFEST.MF
+++ b/tests/org.erlide.util.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Util Tests
 Bundle-SymbolicName: org.erlide.util.tests
-Bundle-Version: 0.62.0.qualifier
+Bundle-Version: 0.63.0.qualifier
 Bundle-Vendor: erlide.org
 Fragment-Host: org.erlide.util;bundle-version="0.19.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/tests/org.erlide.util.tests/pom.xml
+++ b/tests/org.erlide.util.tests/pom.xml
@@ -5,12 +5,12 @@
   <parent>
     <groupId>org.erlide</groupId>
     <artifactId>org.erlide.parent</artifactId>
-        <version>0.62.0-SNAPSHOT</version>
+        <version>0.63.0-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 
   <artifactId>org.erlide.util.tests</artifactId>
-  <version>0.62.0-SNAPSHOT</version>
+  <version>0.63.0-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
     <build>


### PR DESCRIPTION
-   Update supported Erlang versions
 -   Update erlide_kernel version to v0.118.0
 -   Update jinterface to 1.14.1 from OTP 27.3.3
-    Set version to 0.63.0
